### PR TITLE
feat: update all screen headers with time/date and fix RTC usage (Issue #5)

### DIFF
--- a/03.firmware/04.integratedAPP/components/ui/ui_customization.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_customization.c
@@ -7,6 +7,7 @@
 #include "ui_customization.h"
 #include "esp_log.h"
 #include <math.h>
+#include <stdio.h>
 
 static const char *TAG = "UI_CUSTOM";
 
@@ -58,6 +59,12 @@ extern lv_obj_t *ui_HeaderPanel3;
 // AnalogClockWithBackgroud elements
 extern lv_obj_t *ui_AnalogClockWithBackgroud;
 extern lv_obj_t *ui_AnalogClockContainer;
+extern lv_obj_t *ui_DateHolder;  // Analog clock date label
+
+// DateAndTime screen elements
+extern lv_obj_t *ui_DateAndTime;
+extern lv_obj_t *ui_DateHoderLabel;    // Digital clock date (typo in original)
+extern lv_obj_t *ui_TimeHolderLabel;   // Digital clock time
 
 // Track which screens have been customized
 static bool custom_initialized_jp = false;
@@ -68,6 +75,18 @@ static bool custom_initialized_clock = false;
 
 // Clock hands canvas
 static lv_obj_t *clock_canvas = NULL;
+
+// Header elements for each screen (stored for later update)
+typedef struct {
+    lv_obj_t *date_label;
+    lv_obj_t *time_label;
+    lv_obj_t *battery_bar;
+} header_elements_t;
+
+static header_elements_t header_jp = {0};
+static header_elements_t header_atoz = {0};
+static header_elements_t header_cursor = {0};
+static header_elements_t header_settings = {0};
 
 // Clock center and dimensions
 #define CLOCK_CENTER_X  282
@@ -110,8 +129,10 @@ static void apply_highlight_style(lv_obj_t *panel)
 
 /**
  * @brief Create header elements matching Menu style
+ * @param header_panel The header panel to add elements to
+ * @param out_elements Optional pointer to store references for later update
  */
-static void create_header_content(lv_obj_t *header_panel)
+static void create_header_content(lv_obj_t *header_panel, header_elements_t *out_elements)
 {
     if (!header_panel) return;
 
@@ -153,6 +174,13 @@ static void create_header_content(lv_obj_t *header_panel)
         lv_obj_set_style_pad_right(battery_bar,
             lv_obj_get_style_pad_right(battery_bar, LV_PART_MAIN) + 1, LV_PART_MAIN);
     }
+
+    // Store references if requested
+    if (out_elements) {
+        out_elements->date_label = date_label;
+        out_elements->time_label = time_label;
+        out_elements->battery_bar = battery_bar;
+    }
 }
 
 // ============================================================================
@@ -183,7 +211,7 @@ static void customize_jp_keyboard(void)
     apply_highlight_style(ui_Panel15);
     apply_highlight_style(ui_Panel19);
 
-    create_header_content(ui_HeaderPanel);
+    create_header_content(ui_HeaderPanel, &header_jp);
     custom_initialized_jp = true;
     ESP_LOGD(TAG, "JPKeyboard customized");
 }
@@ -196,7 +224,7 @@ static void customize_atoz_keyboard(void)
     if (custom_initialized_atoz) return;
     if (!ui_AtoZKeyboardScreen) return;
 
-    create_header_content(ui_HeaderPanel1);
+    create_header_content(ui_HeaderPanel1, &header_atoz);
     custom_initialized_atoz = true;
     ESP_LOGD(TAG, "AtoZ customized");
 }
@@ -217,7 +245,7 @@ static void customize_cursor(void)
     }
 
     apply_highlight_style(ui_Panel24);
-    create_header_content(ui_HeaderPanel2);
+    create_header_content(ui_HeaderPanel2, &header_cursor);
     custom_initialized_cursor = true;
     ESP_LOGD(TAG, "Cursor customized");
 }
@@ -229,6 +257,11 @@ static void customize_settings(void)
 {
     if (custom_initialized_settings) return;
     if (!ui_SettingScreen) return;
+
+    // Create header for settings screen
+    if (ui_HeaderPanel3) {
+        create_header_content(ui_HeaderPanel3, &header_settings);
+    }
 
     custom_initialized_settings = true;
     ESP_LOGD(TAG, "Settings customized");
@@ -401,11 +434,28 @@ void ui_clock_update_hands(int hour, int minute, int second)
 }
 
 /**
- * @brief Update header with current date/time
+ * @brief Helper to update a single header
+ */
+static void update_header_elements(header_elements_t *h, const char *date_str,
+                                   const char *time_str, int battery_pct)
+{
+    if (h->date_label) {
+        lv_label_set_text(h->date_label, date_str);
+    }
+    if (h->time_label) {
+        lv_label_set_text(h->time_label, time_str);
+    }
+    if (h->battery_bar) {
+        lv_bar_set_value(h->battery_bar, battery_pct, LV_ANIM_OFF);
+    }
+}
+
+/**
+ * @brief Update all headers and clocks with current date/time
  */
 void ui_header_update(const char *date_str, const char *time_str, int battery_pct)
 {
-    // Update Menu header
+    // Update Menu header (original SquareLine-generated elements)
     if (ui_DateHolderLabel) {
         lv_label_set_text(ui_DateHolderLabel, date_str);
     }
@@ -416,7 +466,36 @@ void ui_header_update(const char *date_str, const char *time_str, int battery_pc
         lv_bar_set_value(ui_BatteryBar, battery_pct, LV_ANIM_OFF);
     }
 
-    // TODO: Update other headers when they have similar structure
+    // Update dynamically created headers
+    update_header_elements(&header_jp, date_str, time_str, battery_pct);
+    update_header_elements(&header_atoz, date_str, time_str, battery_pct);
+    update_header_elements(&header_cursor, date_str, time_str, battery_pct);
+    update_header_elements(&header_settings, date_str, time_str, battery_pct);
+
+    // Update Analog Clock calendar
+    if (ui_DateHolder) {
+        // Format for analog clock: "YYYY/MM/DD (Day)  AM/PM"
+        int hour = 0;
+        sscanf(time_str, "%d:", &hour);
+        const char *ampm = (hour < 12) ? "AM" : "PM";
+
+        char clock_date[48];
+        snprintf(clock_date, sizeof(clock_date), "%s  %s", date_str, ampm);
+        lv_label_set_text(ui_DateHolder, clock_date);
+    }
+
+    // Update Digital Clock (DateAndTime screen)
+    if (ui_DateHoderLabel) {
+        lv_label_set_text(ui_DateHoderLabel, date_str);
+    }
+    if (ui_TimeHolderLabel) {
+        // Format time for digital clock: "HH MM" (colons are separate label)
+        int hour = 0, min = 0;
+        sscanf(time_str, "%d:%d", &hour, &min);
+        char digital_time[16];
+        snprintf(digital_time, sizeof(digital_time), "%02d %02d", hour, min);
+        lv_label_set_text(ui_TimeHolderLabel, digital_time);
+    }
 }
 
 /**

--- a/03.firmware/04.integratedAPP/main/main.c
+++ b/03.firmware/04.integratedAPP/main/main.c
@@ -13,6 +13,8 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <time.h>
+#include <sys/time.h>
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
 #include "esp_log.h"
@@ -78,14 +80,26 @@ static void rtc_init(void)
 
     esp_err_t ret = ds3231m_init(i2c_handle, &g_rtc_handle);
     if (ret == ESP_OK) {
-        g_rtc_initialized = true;
-
         struct tm current_time;
         if (ds3231m_get_time(&g_rtc_handle, &current_time) == ESP_OK) {
-            ESP_LOGI(TAG, "RTC time: %04d-%02d-%02d %02d:%02d:%02d",
+            ESP_LOGI(TAG, "DS3231M RTC time: %04d-%02d-%02d %02d:%02d:%02d",
                      1900 + current_time.tm_year, current_time.tm_mon + 1,
                      current_time.tm_mday, current_time.tm_hour,
                      current_time.tm_min, current_time.tm_sec);
+
+            // Set ESP32 internal RTC from DS3231M (read once at startup)
+            // This avoids drift issues caused by frequent I2C queries
+            struct timeval tv;
+            tv.tv_sec = mktime(&current_time);
+            tv.tv_usec = 0;
+            if (settimeofday(&tv, NULL) == 0) {
+                ESP_LOGI(TAG, "ESP32 internal RTC synchronized from DS3231M");
+                g_rtc_initialized = true;
+            } else {
+                ESP_LOGW(TAG, "Failed to set ESP32 internal RTC");
+            }
+        } else {
+            ESP_LOGW(TAG, "Failed to read time from DS3231M");
         }
 
         float temp;
@@ -102,36 +116,42 @@ static const char *WEEKDAY_NAMES[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", 
 
 /**
  * @brief RTC update task - updates UI with current time every second
+ *
+ * Uses ESP32 internal RTC (set from DS3231M at startup) to avoid
+ * drift issues caused by frequent I2C queries to external RTC.
  */
 static void rtc_update_task(void *pvParameters)
 {
     struct tm time_info;
     char date_str[32];
     char time_str[8];
+    time_t now;
 
-    ESP_LOGI(TAG, "RTC update task started");
+    ESP_LOGI(TAG, "RTC update task started (using ESP32 internal RTC)");
 
     while (1) {
         if (g_rtc_initialized) {
-            if (ds3231m_get_time(&g_rtc_handle, &time_info) == ESP_OK) {
-                // Update clock hands (with LVGL lock)
-                if (bsp_display_lock(100)) {
-                    ui_clock_update_hands(time_info.tm_hour, time_info.tm_min, time_info.tm_sec);
+            // Get time from ESP32 internal RTC (not DS3231M)
+            time(&now);
+            localtime_r(&now, &time_info);
 
-                    // Format date: "YYYY/MM/DD (Day)"
-                    snprintf(date_str, sizeof(date_str), "%04d/%02d/%02d (%s)",
-                             1900 + time_info.tm_year, time_info.tm_mon + 1,
-                             time_info.tm_mday, WEEKDAY_NAMES[time_info.tm_wday]);
+            // Update clock hands (with LVGL lock)
+            if (bsp_display_lock(100)) {
+                ui_clock_update_hands(time_info.tm_hour, time_info.tm_min, time_info.tm_sec);
 
-                    // Format time: "HH:MM"
-                    snprintf(time_str, sizeof(time_str), "%02d:%02d",
-                             time_info.tm_hour, time_info.tm_min);
+                // Format date: "YYYY/MM/DD (Day)"
+                snprintf(date_str, sizeof(date_str), "%04d/%02d/%02d (%s)",
+                         1900 + time_info.tm_year, time_info.tm_mon + 1,
+                         time_info.tm_mday, WEEKDAY_NAMES[time_info.tm_wday]);
 
-                    // Update header (battery % is placeholder for now)
-                    ui_header_update(date_str, time_str, 75);
+                // Format time: "HH:MM"
+                snprintf(time_str, sizeof(time_str), "%02d:%02d",
+                         time_info.tm_hour, time_info.tm_min);
 
-                    bsp_display_unlock();
-                }
+                // Update header (battery % is placeholder for now)
+                ui_header_update(date_str, time_str, 75);
+
+                bsp_display_unlock();
             }
         }
 


### PR DESCRIPTION
## Summary
- Add header time/date update support for all screens (JP, AtoZ, Cursor, Settings)
- Update analog clock calendar display with date and AM/PM indicator
- Update digital clock display format (HH MM)
- Fix RTC implementation to avoid external RTC drift from frequent I2C queries

## Changes
- **ui_customization.c**: Add `header_elements_t` struct and update logic for all screen headers
- **main.c**: Read DS3231M once at startup, set ESP32 internal RTC with `settimeofday()`, use `time()`/`localtime_r()` for subsequent updates

## Test plan
- [x] Build succeeds
- [x] All screen headers update with current time/date
- [x] Analog clock calendar shows date + AM/PM
- [x] Digital clock updates correctly
- [x] RTC reads from ESP32 internal clock (no drift from frequent I2C queries)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)