### PR TITLE
feat: implement touchpad gestures for mouse control (Issue #3)

### DIFF
--- a/03.firmware/04.integratedAPP/components/ble_hid/include/ble_hid.h
+++ b/03.firmware/04.integratedAPP/components/ble_hid/include/ble_hid.h
@@ -102,6 +102,28 @@ esp_err_t ble_hid_send_string(const char *str);
  */
 esp_err_t ble_hid_send_consumer(uint16_t usage);
 
+// ============================================================================
+// Mouse Constants and API
+// ============================================================================
+
+/** @brief Mouse button definitions */
+#define MOUSE_BTN_LEFT          0x01
+#define MOUSE_BTN_RIGHT         0x02
+#define MOUSE_BTN_MIDDLE        0x04
+
+/**
+ * @brief Send mouse report
+ *
+ * @param buttons Button state (MOUSE_BTN_LEFT, MOUSE_BTN_RIGHT, MOUSE_BTN_MIDDLE)
+ * @param dx X movement (-127 to 127, positive = right)
+ * @param dy Y movement (-127 to 127, positive = down)
+ * @param wheel Vertical scroll (-127 to 127, positive = up)
+ * @param h_wheel Horizontal scroll (-127 to 127, positive = right)
+ * @return ESP_OK on success
+ */
+esp_err_t ble_hid_send_mouse(uint8_t buttons, int8_t dx, int8_t dy,
+                              int8_t wheel, int8_t h_wheel);
+
 /**
  * @brief Get current BLE HID state
  *

--- a/03.firmware/04.integratedAPP/components/ble_hid/src/ble_hid_init.c
+++ b/03.firmware/04.integratedAPP/components/ble_hid/src/ble_hid_init.c
@@ -44,7 +44,8 @@ static const char *TAG = "BLE_HID";
 #define PNP_VERSION             0x0100
 
 #define REPORT_ID_KEYBOARD      1
-#define REPORT_ID_CONSUMER      2
+#define REPORT_ID_MOUSE         2
+#define REPORT_ID_CONSUMER      3
 
 #define ADV_INTERVAL_MIN_MS     30
 #define ADV_INTERVAL_MAX_MS     60
@@ -189,11 +190,67 @@ static const uint8_t hid_report_descriptor[] = {
 
     0xC0,              // End Collection
 
-    // Consumer Control Report (Report ID = 2)
+    // =========================================================================
+    // Mouse Report (Report ID = 2)
+    // =========================================================================
+    0x05, 0x01,        // Usage Page (Generic Desktop)
+    0x09, 0x02,        // Usage (Mouse)
+    0xA1, 0x01,        // Collection (Application)
+    0x85, REPORT_ID_MOUSE,  // Report ID (2)
+    0x09, 0x01,        // Usage (Pointer)
+    0xA1, 0x00,        // Collection (Physical)
+
+    // Buttons (3 bits: Left, Right, Middle)
+    0x05, 0x09,        // Usage Page (Buttons)
+    0x19, 0x01,        // Usage Minimum (1 - Button 1)
+    0x29, 0x03,        // Usage Maximum (3 - Button 3)
+    0x15, 0x00,        // Logical Minimum (0)
+    0x25, 0x01,        // Logical Maximum (1)
+    0x95, 0x03,        // Report Count (3)
+    0x75, 0x01,        // Report Size (1 bit)
+    0x81, 0x02,        // Input (Data, Variable, Absolute)
+    // Padding (5 bits)
+    0x95, 0x01,        // Report Count (1)
+    0x75, 0x05,        // Report Size (5 bits)
+    0x81, 0x01,        // Input (Constant)
+
+    // X, Y movement (relative)
+    0x05, 0x01,        // Usage Page (Generic Desktop)
+    0x09, 0x30,        // Usage (X)
+    0x09, 0x31,        // Usage (Y)
+    0x15, 0x81,        // Logical Minimum (-127)
+    0x25, 0x7F,        // Logical Maximum (127)
+    0x75, 0x08,        // Report Size (8 bits)
+    0x95, 0x02,        // Report Count (2)
+    0x81, 0x06,        // Input (Data, Variable, Relative)
+
+    // Wheel (vertical scroll)
+    0x09, 0x38,        // Usage (Wheel)
+    0x15, 0x81,        // Logical Minimum (-127)
+    0x25, 0x7F,        // Logical Maximum (127)
+    0x75, 0x08,        // Report Size (8 bits)
+    0x95, 0x01,        // Report Count (1)
+    0x81, 0x06,        // Input (Data, Variable, Relative)
+
+    // Horizontal Scroll (AC Pan)
+    0x05, 0x0C,        // Usage Page (Consumer)
+    0x0A, 0x38, 0x02,  // Usage (AC Pan)
+    0x15, 0x81,        // Logical Minimum (-127)
+    0x25, 0x7F,        // Logical Maximum (127)
+    0x75, 0x08,        // Report Size (8 bits)
+    0x95, 0x01,        // Report Count (1)
+    0x81, 0x06,        // Input (Data, Variable, Relative)
+
+    0xC0,              // End Collection (Physical)
+    0xC0,              // End Collection (Application)
+
+    // =========================================================================
+    // Consumer Control Report (Report ID = 3)
+    // =========================================================================
     0x05, 0x0C,        // Usage Page (Consumer)
     0x09, 0x01,        // Usage (Consumer Control)
     0xA1, 0x01,        // Collection (Application)
-    0x85, REPORT_ID_CONSUMER,
+    0x85, REPORT_ID_CONSUMER,  // Report ID (3)
     0x15, 0x00,        // Logical Minimum (0)
     0x26, 0xFF, 0x03,  // Logical Maximum (1023)
     0x19, 0x00,        // Usage Minimum (0)
@@ -211,6 +268,7 @@ static const uint8_t hid_report_descriptor[] = {
 static bool g_initialized = false;
 static bool g_connected = false;
 static bool g_keyboard_subscribed = false;  // Track notification subscription
+static bool g_mouse_subscribed = false;
 static bool g_consumer_subscribed = false;
 static bool g_auto_reconnect = true;         // Auto-reconnect on disconnect
 static uint16_t g_conn_handle = BLE_HS_CONN_HANDLE_NONE;
@@ -220,6 +278,7 @@ static ble_hid_event_cb_t g_event_callback = NULL;
 
 // GATT characteristic handles
 static uint16_t g_keyboard_handle = 0;
+static uint16_t g_mouse_handle = 0;
 static uint16_t g_consumer_handle = 0;
 
 // ============================================================================
@@ -256,6 +315,7 @@ static const uint8_t pnp_id_value[] = {
 
 static uint8_t keyboard_input_ref[] = { REPORT_ID_KEYBOARD, 0x01 };
 static uint8_t keyboard_output_ref[] = { REPORT_ID_KEYBOARD, 0x02 };
+static uint8_t mouse_input_ref[] = { REPORT_ID_MOUSE, 0x01 };
 static uint8_t consumer_input_ref[] = { REPORT_ID_CONSUMER, 0x01 };
 
 static uint8_t g_battery_level = 100;
@@ -328,7 +388,12 @@ static int gatt_hid_report_access(uint16_t conn_handle, uint16_t attr_handle,
 
     if (ctxt->op == BLE_GATT_ACCESS_OP_READ_CHR) {
         uint8_t empty[8] = {0};
-        int size = (report_id == REPORT_ID_KEYBOARD) ? 8 : 2;
+        int size = 2;  // Default for consumer
+        if (report_id == REPORT_ID_KEYBOARD) {
+            size = 8;  // modifier + reserved + 6 keys
+        } else if (report_id == REPORT_ID_MOUSE) {
+            size = 5;  // buttons + X + Y + wheel + pan
+        }
         os_mbuf_append(ctxt->om, empty, size);
         return 0;
     } else if (ctxt->op == BLE_GATT_ACCESS_OP_WRITE_CHR) {
@@ -442,6 +507,23 @@ static const struct ble_gatt_svc_def gatt_svcs[] = {
                         .uuid = &report_ref_uuid.u,
                         .access_cb = gatt_hid_report_ref_access,
                         .arg = keyboard_output_ref,
+                        .att_flags = BLE_ATT_F_READ,
+                    },
+                    { 0 }
+                },
+            },
+            // Mouse Input Report
+            {
+                .uuid = &hid_report_uuid.u,
+                .access_cb = gatt_hid_report_access,
+                .arg = (void *)(uintptr_t)REPORT_ID_MOUSE,
+                .val_handle = &g_mouse_handle,
+                .flags = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY,
+                .descriptors = (struct ble_gatt_dsc_def[]) {
+                    {
+                        .uuid = &report_ref_uuid.u,
+                        .access_cb = gatt_hid_report_ref_access,
+                        .arg = mouse_input_ref,
                         .att_flags = BLE_ATT_F_READ,
                     },
                     { 0 }
@@ -576,6 +658,7 @@ static int ble_hid_gap_event(struct ble_gap_event *event, void *arg)
             g_conn_handle = event->connect.conn_handle;
             g_connected = true;
             g_keyboard_subscribed = false;
+            g_mouse_subscribed = false;
             g_consumer_subscribed = false;
 
             if (rc == 0) {
@@ -599,6 +682,7 @@ static int ble_hid_gap_event(struct ble_gap_event *event, void *arg)
                 g_conn_handle = event->connect.conn_handle;
                 g_connected = true;
                 g_keyboard_subscribed = false;
+                g_mouse_subscribed = false;
                 g_consumer_subscribed = false;
 
                 ESP_LOGI(TAG, "Connected (quirk)! peer=%02X:%02X:%02X:%02X:%02X:%02X",
@@ -633,6 +717,7 @@ static int ble_hid_gap_event(struct ble_gap_event *event, void *arg)
         g_conn_handle = BLE_HS_CONN_HANDLE_NONE;
         g_connected = false;
         g_keyboard_subscribed = false;
+        g_mouse_subscribed = false;
         g_consumer_subscribed = false;
 
         // Notify callback
@@ -669,6 +754,8 @@ static int ble_hid_gap_event(struct ble_gap_event *event, void *arg)
         // Track notification subscription
         if (event->subscribe.attr_handle == g_keyboard_handle) {
             g_keyboard_subscribed = event->subscribe.cur_notify;
+        } else if (event->subscribe.attr_handle == g_mouse_handle) {
+            g_mouse_subscribed = event->subscribe.cur_notify;
         } else if (event->subscribe.attr_handle == g_consumer_handle) {
             g_consumer_subscribed = event->subscribe.cur_notify;
         }
@@ -1023,6 +1110,36 @@ esp_err_t ble_hid_send_consumer(uint16_t usage)
     om = ble_hs_mbuf_from_flat(report, sizeof(report));
     if (om) {
         ble_gatts_notify_custom(g_conn_handle, g_consumer_handle, om);
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t ble_hid_send_mouse(uint8_t buttons, int8_t dx, int8_t dy,
+                              int8_t wheel, int8_t h_wheel)
+{
+    if (!g_connected || g_mouse_handle == 0) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    // Mouse report: [buttons, dx, dy, wheel, h_wheel] = 5 bytes
+    uint8_t report[5] = {
+        buttons,
+        (uint8_t)dx,
+        (uint8_t)dy,
+        (uint8_t)wheel,
+        (uint8_t)h_wheel
+    };
+
+    struct os_mbuf *om = ble_hs_mbuf_from_flat(report, sizeof(report));
+    if (!om) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    int rc = ble_gatts_notify_custom(g_conn_handle, g_mouse_handle, om);
+    if (rc != 0) {
+        ESP_LOGE(TAG, "Notify mouse failed: %d", rc);
+        return ESP_FAIL;
     }
 
     return ESP_OK;

--- a/03.firmware/04.integratedAPP/components/ui/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/components/ui/CMakeLists.txt
@@ -10,4 +10,5 @@ idf_component_register(
     SRCS ${UI_SOURCES}
     INCLUDE_DIRS "." "screens" "fonts" "images" "components"
     REQUIRES lvgl ble_hid
+    PRIV_REQUIRES bsp_jc4880p443c
 )

--- a/03.firmware/04.integratedAPP/components/ui/ui_navigation.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_navigation.c
@@ -17,12 +17,55 @@
 #include "esp_log.h"
 #include <string.h>
 
+// FreeRTOS
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
 // BLE HID
 #include "ble_hid.h"
 #include "ble_hid_keycodes.h"
 #include "flick_input.h"
 
+// BSP Touch for multi-touch support
+#include "bsp/touch.h"
+#include "esp_lcd_touch.h"
+
 static const char *TAG = "UI_NAV";
+
+// ============================================================================
+// Touchpad Configuration
+// ============================================================================
+
+#define TOUCHPAD_TAP_THRESHOLD      12      // Max movement for tap (pixels)
+#define TOUCHPAD_TAP_TIME_MS        300     // Max time for tap (ms)
+#define TOUCHPAD_SCROLL_THRESHOLD   8       // Min accumulated movement for scroll start
+#define TOUCHPAD_PIXELS_PER_SCROLL  15      // Pixels of movement per scroll tick
+#define TOUCHPAD_SENSITIVITY        2       // Mouse movement multiplier
+#define TOUCHPAD_STRENGTH_2FINGER   120     // Strength threshold to detect close 2-fingers
+
+// Touchpad operating mode
+typedef enum {
+    TOUCHPAD_MODE_MOUSE,    // Switch OFF: mouse movement + clicks
+    TOUCHPAD_MODE_SCROLL,   // Switch ON: scroll operations
+} touchpad_mode_t;
+
+// Touchpad gesture state
+typedef struct {
+    touchpad_mode_t mode;
+    lv_point_t start_pos;           // Touch start position
+    lv_point_t last_pos;            // Last touch position (for cursor)
+    lv_point_t scroll_anchor;       // Anchor for scroll calculation
+    int32_t scroll_accum_x;         // Accumulated X movement for scroll
+    int32_t scroll_accum_y;         // Accumulated Y movement for scroll
+    uint8_t initial_finger_count;   // Finger count at touch start
+    uint32_t touch_start_time;      // Touch start timestamp (ms)
+    bool is_active;                 // Currently tracking a touch
+} touchpad_state_t;
+
+static touchpad_state_t g_touchpad_state = {
+    .mode = TOUCHPAD_MODE_MOUSE,
+    .is_active = false
+};
 
 // Forward declarations for screen init functions
 extern void ui_JPKeyboardScreen_screen_init(void);
@@ -91,6 +134,16 @@ extern lv_obj_t *ui_Image5;         // Enter image (inside Panel21)
 
 // AtoZKeyboardScreen
 extern lv_obj_t *ui_OtherKeyboard;  // lv_keyboard widget
+
+// TouchAndScrollPanel (touchpad area on each keyboard screen)
+extern lv_obj_t *ui_TouchAndScrollPanel;    // JPKeyboardScreen
+extern lv_obj_t *ui_TouchAndScrollPanel1;   // AtoZKeyboardScreen
+extern lv_obj_t *ui_TouchAndScrollPanel2;   // CursorScreen
+
+// Mode toggle switches (inside TouchAndScrollPanel)
+extern lv_obj_t *ui_Switch1;    // JPKeyboardScreen
+extern lv_obj_t *ui_Switch2;    // AtoZKeyboardScreen
+extern lv_obj_t *ui_Switch3;    // CursorScreen
 
 // CursorScreen buttons (panels and their clickable children)
 extern lv_obj_t *ui_Panel1;         // Container for Image6
@@ -212,6 +265,271 @@ static void nav_light_on(lv_event_t *e)
     if (lv_event_get_code(e) == LV_EVENT_RELEASED) {
         // Light On - not implemented yet
     }
+}
+
+// ============================================================================
+// Touchpad Event Handlers
+// ============================================================================
+
+/**
+ * @brief Read current finger count from touch controller
+ *
+ * Performs a thread-safe I2C read to get the current multi-touch state.
+ * Also detects close 2-finger touches via strength analysis.
+ */
+static uint8_t touchpad_read_finger_count(void)
+{
+    esp_lcd_touch_handle_t handle = bsp_touch_get_handle();
+    if (!handle) {
+        return 1;  // Fallback to single finger
+    }
+
+    // Read fresh touch data with thread-safe access
+    uint16_t x[5], y[5], strength[5];
+    uint8_t point_num = 0;
+
+    esp_err_t ret = bsp_touch_read_data_safe(
+        handle, x, y, strength, &point_num, 5, pdMS_TO_TICKS(10)
+    );
+
+    if (ret == ESP_OK && point_num > 0) {
+        // Check for close 2-fingers: single point with high strength
+        if (point_num == 1 && strength[0] >= TOUCHPAD_STRENGTH_2FINGER) {
+            ESP_LOGW(TAG, "Touch: 1 point, strength=%d -> treating as 2 fingers", strength[0]);
+            return 2;
+        }
+        ESP_LOGD(TAG, "Touch read: %d fingers, strength[0]=%d", point_num, strength[0]);
+        return point_num;
+    }
+    return 1;
+}
+
+/**
+ * @brief Handle touchpad press start
+ */
+static void touchpad_pressed_cb(lv_event_t *e)
+{
+    lv_point_t point;
+    lv_indev_t *indev = lv_indev_active();
+    lv_indev_get_point(indev, &point);
+
+    g_touchpad_state.start_pos = point;
+    g_touchpad_state.last_pos = point;
+    g_touchpad_state.scroll_anchor = point;
+    g_touchpad_state.scroll_accum_x = 0;
+    g_touchpad_state.scroll_accum_y = 0;
+    g_touchpad_state.initial_finger_count = touchpad_read_finger_count();
+    g_touchpad_state.touch_start_time = lv_tick_get();
+    g_touchpad_state.is_active = true;
+
+    ESP_LOGW(TAG, "Touchpad pressed: fingers=%d, pos=(%ld,%ld)",
+             g_touchpad_state.initial_finger_count, point.x, point.y);
+}
+
+/**
+ * @brief Send proportional scroll based on accumulated movement
+ *
+ * Calculates scroll ticks based on total movement from anchor point.
+ * Updates anchor when scroll is sent to allow continuous scrolling.
+ */
+static void touchpad_send_proportional_scroll(lv_point_t *point)
+{
+    // Calculate total movement from scroll anchor
+    int32_t total_dx = point->x - g_touchpad_state.scroll_anchor.x;
+    int32_t total_dy = point->y - g_touchpad_state.scroll_anchor.y;
+    int32_t abs_dx = (total_dx < 0) ? -total_dx : total_dx;
+    int32_t abs_dy = (total_dy < 0) ? -total_dy : total_dy;
+
+    // Only start scrolling after threshold
+    if (abs_dx < TOUCHPAD_SCROLL_THRESHOLD && abs_dy < TOUCHPAD_SCROLL_THRESHOLD) {
+        return;
+    }
+
+    // Determine primary scroll direction and calculate ticks
+    int8_t wheel = 0, h_wheel = 0;
+
+    if (abs_dy >= abs_dx) {
+        // Vertical scroll
+        int32_t scroll_ticks = total_dy / TOUCHPAD_PIXELS_PER_SCROLL;
+        if (scroll_ticks != 0) {
+            // Traditional scroll direction (swipe down = scroll down)
+            wheel = (int8_t)(scroll_ticks > 127 ? 127 : (scroll_ticks < -127 ? -127 : scroll_ticks));
+            // Update anchor by consumed pixels
+            g_touchpad_state.scroll_anchor.y += scroll_ticks * TOUCHPAD_PIXELS_PER_SCROLL;
+        }
+    } else {
+        // Horizontal scroll
+        int32_t scroll_ticks = total_dx / TOUCHPAD_PIXELS_PER_SCROLL;
+        if (scroll_ticks != 0) {
+            // Inverted horizontal (swipe right = scroll left)
+            h_wheel = (int8_t)(scroll_ticks > 127 ? 127 : (scroll_ticks < -127 ? -127 : -scroll_ticks));
+            // Update anchor by consumed pixels
+            g_touchpad_state.scroll_anchor.x += scroll_ticks * TOUCHPAD_PIXELS_PER_SCROLL;
+        }
+    }
+
+    if (wheel != 0 || h_wheel != 0) {
+        ble_hid_send_mouse(0, 0, 0, wheel, h_wheel);
+    }
+}
+
+/**
+ * @brief Handle touchpad movement (pressing)
+ */
+static void touchpad_pressing_cb(lv_event_t *e)
+{
+    if (!g_touchpad_state.is_active) return;
+
+    lv_point_t point;
+    lv_indev_t *indev = lv_indev_active();
+    lv_indev_get_point(indev, &point);
+
+    int32_t dx = point.x - g_touchpad_state.last_pos.x;
+    int32_t dy = point.y - g_touchpad_state.last_pos.y;
+
+    // Use initial finger count (captured at touch start)
+    uint8_t fingers = g_touchpad_state.initial_finger_count;
+
+    if (g_touchpad_state.mode == TOUCHPAD_MODE_MOUSE) {
+        // Mouse mode: single finger = cursor movement
+        if (fingers == 1 && (dx != 0 || dy != 0)) {
+            // Scale movement for sensitivity
+            int32_t scaled_dx = dx * TOUCHPAD_SENSITIVITY;
+            int32_t scaled_dy = dy * TOUCHPAD_SENSITIVITY;
+
+            // Clamp to valid range
+            if (scaled_dx > 127) scaled_dx = 127;
+            if (scaled_dx < -127) scaled_dx = -127;
+            if (scaled_dy > 127) scaled_dy = 127;
+            if (scaled_dy < -127) scaled_dy = -127;
+
+            if (scaled_dx != 0 || scaled_dy != 0) {
+                ble_hid_send_mouse(0, (int8_t)scaled_dx, (int8_t)scaled_dy, 0, 0);
+            }
+        }
+        // 2-finger movement: proportional scroll
+        else if (fingers >= 2) {
+            touchpad_send_proportional_scroll(&point);
+        }
+    } else {
+        // Scroll mode: any movement = proportional scroll
+        touchpad_send_proportional_scroll(&point);
+    }
+
+    g_touchpad_state.last_pos = point;
+}
+
+/**
+ * @brief Handle touchpad release
+ */
+static void touchpad_released_cb(lv_event_t *e)
+{
+    if (!g_touchpad_state.is_active) return;
+
+    lv_point_t point;
+    lv_indev_t *indev = lv_indev_active();
+    lv_indev_get_point(indev, &point);
+
+    // Calculate total movement
+    int32_t total_dx = point.x - g_touchpad_state.start_pos.x;
+    int32_t total_dy = point.y - g_touchpad_state.start_pos.y;
+    int32_t abs_dx = (total_dx < 0) ? -total_dx : total_dx;
+    int32_t abs_dy = (total_dy < 0) ? -total_dy : total_dy;
+
+    // Calculate duration
+    uint32_t duration = lv_tick_get() - g_touchpad_state.touch_start_time;
+
+    // Check for tap gesture (small movement, short duration)
+    bool is_tap = (abs_dx < TOUCHPAD_TAP_THRESHOLD &&
+                   abs_dy < TOUCHPAD_TAP_THRESHOLD &&
+                   duration < TOUCHPAD_TAP_TIME_MS);
+
+    ESP_LOGW(TAG, "Touchpad released: fingers=%d, movement=(%ld,%ld), duration=%lums, is_tap=%d",
+             g_touchpad_state.initial_finger_count, total_dx, total_dy, (unsigned long)duration, is_tap);
+
+    if (is_tap) {
+        uint8_t button = 0;
+
+        if (g_touchpad_state.mode == TOUCHPAD_MODE_MOUSE) {
+            // Mouse mode tap gestures
+            switch (g_touchpad_state.initial_finger_count) {
+                case 1:
+                    button = MOUSE_BTN_LEFT;
+                    ESP_LOGW(TAG, "Tap gesture: Left click (1 finger)");
+                    break;
+                case 2:
+                    button = MOUSE_BTN_RIGHT;
+                    ESP_LOGW(TAG, "Tap gesture: Right click (2 fingers)");
+                    break;
+                case 3:
+                default:
+                    button = MOUSE_BTN_MIDDLE;
+                    ESP_LOGW(TAG, "Tap gesture: Middle click (%d fingers)",
+                             g_touchpad_state.initial_finger_count);
+                    break;
+            }
+        } else {
+            // Scroll mode: tap = middle click
+            button = MOUSE_BTN_MIDDLE;
+            ESP_LOGW(TAG, "Tap gesture (scroll mode): Middle click");
+        }
+
+        // Send click (press then release)
+        ble_hid_send_mouse(button, 0, 0, 0, 0);
+        vTaskDelay(pdMS_TO_TICKS(20));
+        ble_hid_send_mouse(0, 0, 0, 0, 0);
+    }
+
+    g_touchpad_state.is_active = false;
+}
+
+/**
+ * @brief Handle mode switch toggle
+ */
+static void touchpad_switch_cb(lv_event_t *e)
+{
+    lv_obj_t *sw = lv_event_get_target(e);
+    bool checked = lv_obj_has_state(sw, LV_STATE_CHECKED);
+
+    g_touchpad_state.mode = checked ? TOUCHPAD_MODE_SCROLL : TOUCHPAD_MODE_MOUSE;
+    ESP_LOGI(TAG, "Touchpad mode: %s", checked ? "SCROLL" : "MOUSE");
+
+    // Sync all switches to same state
+    if (ui_Switch1 && ui_Switch1 != sw) {
+        if (checked) lv_obj_add_state(ui_Switch1, LV_STATE_CHECKED);
+        else lv_obj_remove_state(ui_Switch1, LV_STATE_CHECKED);
+    }
+    if (ui_Switch2 && ui_Switch2 != sw) {
+        if (checked) lv_obj_add_state(ui_Switch2, LV_STATE_CHECKED);
+        else lv_obj_remove_state(ui_Switch2, LV_STATE_CHECKED);
+    }
+    if (ui_Switch3 && ui_Switch3 != sw) {
+        if (checked) lv_obj_add_state(ui_Switch3, LV_STATE_CHECKED);
+        else lv_obj_remove_state(ui_Switch3, LV_STATE_CHECKED);
+    }
+}
+
+/**
+ * @brief Register touchpad event handlers for a TouchAndScrollPanel
+ */
+static void setup_touchpad_panel(lv_obj_t *panel, lv_obj_t *sw)
+{
+    if (!panel) return;
+
+    // Make panel clickable
+    lv_obj_add_flag(panel, LV_OBJ_FLAG_CLICKABLE);
+
+    // Register touch events
+    lv_obj_add_event_cb(panel, touchpad_pressed_cb, LV_EVENT_PRESSED, NULL);
+    lv_obj_add_event_cb(panel, touchpad_pressing_cb, LV_EVENT_PRESSING, NULL);
+    lv_obj_add_event_cb(panel, touchpad_released_cb, LV_EVENT_RELEASED, NULL);
+
+    // Register switch mode toggle
+    if (sw) {
+        lv_obj_add_event_cb(sw, touchpad_switch_cb, LV_EVENT_VALUE_CHANGED, NULL);
+    }
+
+    ESP_LOGD(TAG, "Touchpad panel setup complete");
 }
 
 // ============================================================================
@@ -719,6 +1037,9 @@ static void setup_jp_keyboard_nav(void)
         ESP_LOGD(TAG, "JP: Symbol panel");
     }
 
+    // Touchpad setup
+    setup_touchpad_panel(ui_TouchAndScrollPanel, ui_Switch1);
+
     last_jp_screen = ui_JPKeyboardScreen;
     ESP_LOGD(TAG, "JPKeyboard nav ready");
 }
@@ -732,6 +1053,9 @@ static void setup_atoz_keyboard_nav(void)
         // Character output
         lv_obj_add_event_cb(ui_OtherKeyboard, atoz_keyboard_char_cb, LV_EVENT_VALUE_CHANGED, NULL);
     }
+
+    // Touchpad setup
+    setup_touchpad_panel(ui_TouchAndScrollPanel1, ui_Switch2);
 
     last_atoz_screen = ui_AtoZKeyboardScreen;
     ESP_LOGD(TAG, "AtoZ nav ready");
@@ -765,6 +1089,9 @@ static void setup_cursor_nav(void)
     setup_cursor_key(ui_Label25, "Undo");
     setup_cursor_key(ui_Label21, "Redo");
     setup_cursor_key(ui_Label26, "Backspace");
+
+    // Touchpad setup
+    setup_touchpad_panel(ui_TouchAndScrollPanel2, ui_Switch3);
 
     last_cursor_screen = ui_CursorScreen;
     ESP_LOGD(TAG, "Cursor nav ready");


### PR DESCRIPTION
## Summary
- TouchAndScrollPanel をタッチパッドとして機能させ、マウスカーソル移動とジェスチャー操作を実装
- BLE HID マウスレポート（Report ID 2）を追加し、複合デバイス（キーボード+マウス）として動作

## 機能

### マウスモード（Switch OFF）
| ジェスチャー | 動作 |
|-------------|------|
| 1本指ドラッグ | カーソル移動 |
| 1本指タップ | 左クリック |
| 2本指タップ | 右クリック |
| 3本指タップ | 中クリック |
| 2本指ドラッグ | スクロール（縦/横） |

### スクロールモード（Switch ON）
| ジェスチャー | 動作 |
|-------------|------|
| ドラッグ | スクロール |
| タップ | 中クリック |

## 技術的実装
- BSP タッチAPI（`bsp_touch_read_data_safe`）で スレッドセーフなマルチタッチ取得
- タッチ強度による近接2本指検出（指が近くても2本指として認識）
- 比例スクロール: ドラッグ距離に応じたスクロール量

## 変更ファイル
- `components/ble_hid/include/ble_hid.h` - マウスAPI追加
- `components/ble_hid/src/ble_hid_init.c` - マウスレポート記述子・送信関数
- `components/ui/CMakeLists.txt` - BSP依存追加
- `components/ui/ui_navigation.c` - タッチパッドイベント処理

## Test plan
- [x] 1本指ドラッグでカーソル移動
- [x] 1本指タップで左クリック
- [x] 2本指タップで右クリック
- [x] 3本指タップで中クリック
- [x] 2本指ドラッグでスクロール
- [x] スクロールモード切替で動作変更

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)