### PR TITLE
feat: SDカードから背景画像の読み込み (Issue #4)

### DIFF
--- a/03.firmware/04.integratedAPP/components/common/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/components/common/CMakeLists.txt
@@ -1,0 +1,10 @@
+idf_component_register(
+    SRCS
+        "src/logger.c"
+        "src/event_queue.c"
+    INCLUDE_DIRS
+        "include"
+    REQUIRES
+        freertos
+        esp_timer
+)

--- a/03.firmware/04.integratedAPP/components/common/include/event_queue.h
+++ b/03.firmware/04.integratedAPP/components/common/include/event_queue.h
@@ -1,0 +1,217 @@
+/**
+ * @file event_queue.h
+ * @brief Handy Keyboard - イベントキューシステム
+ *
+ * タッチパッド、キーボード、マウス、システムイベントの管理
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "freertos/FreeRTOS.h"
+#include "freertos/queue.h"
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// キューサイズ定義
+#define EVENT_QUEUE_SIZE_INPUT      32    ///< 入力イベント（タッチ、物理キー）
+#define EVENT_QUEUE_SIZE_HID        16    ///< HID レポート（USB/BLE出力）
+#define EVENT_QUEUE_SIZE_SYSTEM     8     ///< システムイベント（設定変更等）
+
+/**
+ * @brief キュー送信ポリシー
+ */
+typedef enum {
+    QUEUE_POLICY_NO_WAIT,      ///< すぐに失敗（ノンブロッキング）
+    QUEUE_POLICY_BLOCK_10MS,   ///< 10ms まで待機
+    QUEUE_POLICY_BLOCK_50MS,   ///< 50ms まで待機
+    QUEUE_POLICY_BLOCK_100MS,  ///< 100ms まで待機
+} queue_send_policy_t;
+
+/**
+ * @brief 入力イベント種別
+ */
+typedef enum {
+    EVENT_TOUCH_TAP,           ///< タップ（クリック相当）
+    EVENT_TOUCH_DOUBLE_TAP,    ///< ダブルタップ
+    EVENT_TOUCH_FLICK,         ///< フリック入力
+    EVENT_TOUCH_TWO_FINGER_SCROLL,  ///< 2本指スクロール
+    EVENT_TOUCH_HOLD,          ///< 長押し
+    EVENT_KEY_PRESS,           ///< キー押下
+    EVENT_KEY_RELEASE,         ///< キー離上
+    EVENT_SYSTEM_MODE_CHANGE,  ///< モード変更（キーボード/マウス/時計）
+    EVENT_SYSTEM_SETTING_CHANGE,  ///< 設定変更
+} input_event_type_t;
+
+/**
+ * @brief タッチイベントデータ
+ */
+typedef struct {
+    uint16_t x;                ///< X座標
+    uint16_t y;                ///< Y座標
+    uint8_t finger_count;      ///< 指の本数（マルチタッチ）
+    int16_t flick_direction;   ///< フリック方向（0=上, 90=右, 180=下, 270=左）
+    int8_t scroll_x;           ///< スクロール量 X
+    int8_t scroll_y;           ///< スクロール量 Y
+} touch_event_data_t;
+
+/**
+ * @brief キーイベントデータ
+ */
+typedef struct {
+    uint16_t keycode;          ///< キーコード
+    uint8_t modifiers;         ///< モディファイア（Ctrl, Shift等）
+} key_event_data_t;
+
+/**
+ * @brief システムイベントデータ
+ */
+typedef struct {
+    uint8_t mode;              ///< モード番号
+    uint8_t param;             ///< パラメータ
+} system_event_data_t;
+
+/**
+ * @brief 入力イベント統合構造体
+ */
+typedef struct {
+    input_event_type_t type;   ///< イベント種別
+    uint32_t timestamp;        ///< タイムスタンプ（ms）
+    union {
+        touch_event_data_t touch;
+        key_event_data_t key;
+        system_event_data_t system;
+    } data;
+} input_event_t;
+
+/**
+ * @brief HID レポート種別
+ */
+typedef enum {
+    HID_REPORT_KEYBOARD,       ///< キーボードレポート
+    HID_REPORT_MOUSE,          ///< マウスレポート
+    HID_REPORT_CONSUMER,       ///< コンシューマーコントロール
+} hid_report_type_t;
+
+/**
+ * @brief キーボードレポート（6KRO Boot Protocol）
+ */
+typedef struct {
+    uint8_t modifiers;         ///< モディファイア（Ctrl, Shift等）
+    uint8_t reserved;          ///< 予約
+    uint8_t keys[6];           ///< 同時押しキー（最大6個）
+} kbd_report_t;
+
+/**
+ * @brief マウスレポート
+ */
+typedef struct {
+    uint8_t buttons;           ///< ボタン状態（bit0=左, bit1=右, bit2=中央）
+    int8_t x;                  ///< X軸移動量
+    int8_t y;                  ///< Y軸移動量
+    int8_t wheel;              ///< ホイール量
+} mouse_report_t;
+
+/**
+ * @brief コンシューマーコントロールレポート
+ */
+typedef struct {
+    uint16_t usage;            ///< Usage ID（音量、再生等）
+} consumer_report_t;
+
+/**
+ * @brief HID レポート統合構造体
+ */
+typedef struct {
+    hid_report_type_t type;    ///< レポート種別
+    union {
+        kbd_report_t keyboard;
+        mouse_report_t mouse;
+        consumer_report_t consumer;
+    } data;
+} hid_report_t;
+
+/**
+ * @brief イベントキューシステム初期化
+ *
+ * 各種イベントキューを作成
+ *
+ * @return ESP_OK 成功
+ */
+esp_err_t event_queue_init(void);
+
+/**
+ * @brief 入力イベント送信
+ *
+ * @param event イベントデータ
+ * @param policy 送信ポリシー
+ * @return true 成功, false 失敗
+ */
+bool input_event_send(const input_event_t *event, queue_send_policy_t policy);
+
+/**
+ * @brief 入力イベント受信
+ *
+ * @param event イベントデータ格納先
+ * @param wait_ticks 待機時間（FreeRTOS ticks）
+ * @return true 受信成功, false タイムアウト
+ */
+bool input_event_receive(input_event_t *event, TickType_t wait_ticks);
+
+/**
+ * @brief HID レポート送信
+ *
+ * @param report レポートデータ
+ * @param policy 送信ポリシー
+ * @return true 成功, false 失敗
+ */
+bool hid_report_send(const hid_report_t *report, queue_send_policy_t policy);
+
+/**
+ * @brief HID レポート受信
+ *
+ * @param report レポートデータ格納先
+ * @param wait_ticks 待機時間（FreeRTOS ticks）
+ * @return true 受信成功, false タイムアウト
+ */
+bool hid_report_receive(hid_report_t *report, TickType_t wait_ticks);
+
+/**
+ * @brief システムイベント送信
+ *
+ * @param event イベントデータ
+ * @param policy 送信ポリシー
+ * @return true 成功, false 失敗
+ */
+bool system_event_send(const input_event_t *event, queue_send_policy_t policy);
+
+/**
+ * @brief システムイベント受信
+ *
+ * @param event イベントデータ格納先
+ * @param wait_ticks 待機時間（FreeRTOS ticks）
+ * @return true 受信成功, false タイムアウト
+ */
+bool system_event_receive(input_event_t *event, TickType_t wait_ticks);
+
+/**
+ * @brief 入力イベントキューの待機数取得
+ *
+ * @return 待機中のイベント数
+ */
+size_t input_event_queue_waiting(void);
+
+/**
+ * @brief HID レポートキューの待機数取得
+ *
+ * @return 待機中のレポート数
+ */
+size_t hid_report_queue_waiting(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/03.firmware/04.integratedAPP/components/common/include/keyboard_info.h
+++ b/03.firmware/04.integratedAPP/components/common/include/keyboard_info.h
@@ -1,0 +1,74 @@
+/**
+ * @file keyboard_info.h
+ * @brief Handy Keyboard - ハードウェア情報定義
+ *
+ * デバイスメタデータ、USB識別情報、ファームウェアバージョンを定義
+ */
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief デバイス基本情報
+ */
+#define DEVICE_NAME             "Handy Keyboard"
+#define DEVICE_MANUFACTURER     "doublebooking"
+#define DEVICE_MAINTAINER       "doublebooking"
+#define DEVICE_URL              "https://github.com/doublebooking141"
+
+/**
+ * @brief USB識別情報
+ * Note: sdkconfig.defaults の TinyUSB 設定と一致させる
+ */
+#define USB_VID                 0xCAFE      ///< Vendor ID
+#define USB_PID                 0x4001      ///< Product ID (Handy Keyboard)
+#define USB_DEVICE_VERSION      0x0100      ///< Device Version (BCD: 1.0.0)
+
+/**
+ * @brief USB文字列（String Descriptors用）
+ */
+#define USB_MANUFACTURER_STRING DEVICE_MANUFACTURER
+#define USB_PRODUCT_STRING      DEVICE_NAME
+#define USB_SERIAL_STRING       "HK20260112"  ///< シリアル番号
+
+/**
+ * @brief ファームウェアバージョン
+ */
+#define FIRMWARE_VERSION_MAJOR  0
+#define FIRMWARE_VERSION_MINOR  1
+#define FIRMWARE_VERSION_PATCH  0
+#define FIRMWARE_VERSION_STRING "0.1.0"
+
+/**
+ * @brief ハードウェア情報（ESP32-P4 + ESP32-C6）
+ */
+#define HW_MCU_MAIN            "ESP32-P4"      ///< メインMCU（RISC-V dual-core 400MHz）
+#define HW_MCU_WIRELESS        "ESP32-C6"      ///< 無線MCU（WiFi 6 + BLE 5.4）
+#define HW_DISPLAY_SIZE        "4.3\""         ///< ディスプレイサイズ
+#define HW_DISPLAY_RESOLUTION  "480x800"       ///< ディスプレイ解像度
+#define HW_DISPLAY_TYPE        "MIPI-DSI"      ///< ディスプレイインターフェース
+
+/**
+ * @brief I2C周辺デバイス情報
+ */
+#define HW_I2C_SDA_GPIO        7               ///< I2C SDA (GPIO7)
+#define HW_I2C_SCL_GPIO        8               ///< I2C SCL (GPIO8)
+#define HW_I2C_FREQ_HZ         400000          ///< I2C クロック周波数 (400kHz)
+
+// I2Cデバイスアドレス
+#define HW_I2C_ADDR_ES8311     0x18            ///< ES8311 Audio Codec
+#define HW_I2C_ADDR_GT911      0x5D            ///< GT911 Touch Controller
+#define HW_I2C_ADDR_DS3231M    0x68            ///< DS3231M RTC
+
+/**
+ * @brief メモリ構成
+ */
+#define HW_FLASH_SIZE_MB       16              ///< Flash サイズ (16MB)
+#define HW_PSRAM_SIZE_MB       32              ///< PSRAM サイズ (32MB)
+
+#ifdef __cplusplus
+}
+#endif

--- a/03.firmware/04.integratedAPP/components/common/include/logger.h
+++ b/03.firmware/04.integratedAPP/components/common/include/logger.h
@@ -1,0 +1,51 @@
+/**
+ * @file logger.h
+ * @brief Handy Keyboard - ログ出力ラッパー
+ *
+ * ESP-IDF の esp_log.h を拡張したロギングインフラ
+ */
+
+#pragma once
+
+#include "esp_log.h"
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief ロガー初期化
+ *
+ * ログレベルの設定、出力先の初期化を行う
+ *
+ * @return ESP_OK 成功
+ */
+esp_err_t logger_init(void);
+
+/**
+ * @brief コンポーネント別ログレベル設定
+ *
+ * @param tag コンポーネントタグ
+ * @param level ログレベル (ESP_LOG_NONE, ESP_LOG_ERROR, ESP_LOG_WARN, ESP_LOG_INFO, ESP_LOG_DEBUG, ESP_LOG_VERBOSE)
+ */
+void logger_set_level(const char* tag, esp_log_level_t level);
+
+/**
+ * @brief ログレベル文字列取得
+ *
+ * @param level ログレベル
+ * @return レベル文字列 ("ERROR", "WARN", "INFO", "DEBUG", "VERBOSE")
+ */
+const char* logger_level_to_string(esp_log_level_t level);
+
+// 便利マクロ（コンポーネントタグを自動挿入）
+#define LOG_E(tag, format, ...) ESP_LOGE(tag, format, ##__VA_ARGS__)
+#define LOG_W(tag, format, ...) ESP_LOGW(tag, format, ##__VA_ARGS__)
+#define LOG_I(tag, format, ...) ESP_LOGI(tag, format, ##__VA_ARGS__)
+#define LOG_D(tag, format, ...) ESP_LOGD(tag, format, ##__VA_ARGS__)
+#define LOG_V(tag, format, ...) ESP_LOGV(tag, format, ##__VA_ARGS__)
+
+#ifdef __cplusplus
+}
+#endif

--- a/03.firmware/04.integratedAPP/components/common/src/event_queue.c
+++ b/03.firmware/04.integratedAPP/components/common/src/event_queue.c
@@ -1,0 +1,161 @@
+/**
+ * @file event_queue.c
+ * @brief Handy Keyboard - イベントキューシステム実装
+ */
+
+#include "event_queue.h"
+#include "logger.h"
+#include <string.h>
+
+static const char *TAG = "EVENT_QUEUE";
+
+// イベントキューハンドル
+static QueueHandle_t input_event_queue = NULL;
+static QueueHandle_t hid_report_queue = NULL;
+static QueueHandle_t system_event_queue = NULL;
+
+/**
+ * @brief ポリシーに応じた待機時間取得
+ */
+static TickType_t get_wait_ticks(queue_send_policy_t policy)
+{
+    switch (policy) {
+        case QUEUE_POLICY_NO_WAIT:
+            return 0;
+        case QUEUE_POLICY_BLOCK_10MS:
+            return pdMS_TO_TICKS(10);
+        case QUEUE_POLICY_BLOCK_50MS:
+            return pdMS_TO_TICKS(50);
+        case QUEUE_POLICY_BLOCK_100MS:
+            return pdMS_TO_TICKS(100);
+        default:
+            return 0;
+    }
+}
+
+esp_err_t event_queue_init(void)
+{
+    ESP_LOGI(TAG, "Initializing event queue system");
+
+    // 入力イベントキュー作成
+    input_event_queue = xQueueCreate(EVENT_QUEUE_SIZE_INPUT, sizeof(input_event_t));
+    if (input_event_queue == NULL) {
+        ESP_LOGE(TAG, "Failed to create input event queue");
+        return ESP_ERR_NO_MEM;
+    }
+
+    // HID レポートキュー作成
+    hid_report_queue = xQueueCreate(EVENT_QUEUE_SIZE_HID, sizeof(hid_report_t));
+    if (hid_report_queue == NULL) {
+        ESP_LOGE(TAG, "Failed to create HID report queue");
+        return ESP_ERR_NO_MEM;
+    }
+
+    // システムイベントキュー作成
+    system_event_queue = xQueueCreate(EVENT_QUEUE_SIZE_SYSTEM, sizeof(input_event_t));
+    if (system_event_queue == NULL) {
+        ESP_LOGE(TAG, "Failed to create system event queue");
+        return ESP_ERR_NO_MEM;
+    }
+
+    ESP_LOGI(TAG, "Event queues created successfully");
+    ESP_LOGI(TAG, "  Input queue: %d slots", EVENT_QUEUE_SIZE_INPUT);
+    ESP_LOGI(TAG, "  HID queue: %d slots", EVENT_QUEUE_SIZE_HID);
+    ESP_LOGI(TAG, "  System queue: %d slots", EVENT_QUEUE_SIZE_SYSTEM);
+
+    return ESP_OK;
+}
+
+bool input_event_send(const input_event_t *event, queue_send_policy_t policy)
+{
+    if (input_event_queue == NULL || event == NULL) {
+        return false;
+    }
+
+    TickType_t wait = get_wait_ticks(policy);
+    BaseType_t result = xQueueSend(input_event_queue, event, wait);
+
+    if (result != pdTRUE) {
+        ESP_LOGW(TAG, "Input event queue full (policy: %d)", policy);
+        return false;
+    }
+
+    return true;
+}
+
+bool input_event_receive(input_event_t *event, TickType_t wait_ticks)
+{
+    if (input_event_queue == NULL || event == NULL) {
+        return false;
+    }
+
+    return xQueueReceive(input_event_queue, event, wait_ticks) == pdTRUE;
+}
+
+bool hid_report_send(const hid_report_t *report, queue_send_policy_t policy)
+{
+    if (hid_report_queue == NULL || report == NULL) {
+        return false;
+    }
+
+    TickType_t wait = get_wait_ticks(policy);
+    BaseType_t result = xQueueSend(hid_report_queue, report, wait);
+
+    if (result != pdTRUE) {
+        ESP_LOGW(TAG, "HID report queue full (policy: %d)", policy);
+        return false;
+    }
+
+    return true;
+}
+
+bool hid_report_receive(hid_report_t *report, TickType_t wait_ticks)
+{
+    if (hid_report_queue == NULL || report == NULL) {
+        return false;
+    }
+
+    return xQueueReceive(hid_report_queue, report, wait_ticks) == pdTRUE;
+}
+
+bool system_event_send(const input_event_t *event, queue_send_policy_t policy)
+{
+    if (system_event_queue == NULL || event == NULL) {
+        return false;
+    }
+
+    TickType_t wait = get_wait_ticks(policy);
+    BaseType_t result = xQueueSend(system_event_queue, event, wait);
+
+    if (result != pdTRUE) {
+        ESP_LOGW(TAG, "System event queue full (policy: %d)", policy);
+        return false;
+    }
+
+    return true;
+}
+
+bool system_event_receive(input_event_t *event, TickType_t wait_ticks)
+{
+    if (system_event_queue == NULL || event == NULL) {
+        return false;
+    }
+
+    return xQueueReceive(system_event_queue, event, wait_ticks) == pdTRUE;
+}
+
+size_t input_event_queue_waiting(void)
+{
+    if (input_event_queue == NULL) {
+        return 0;
+    }
+    return (size_t)uxQueueMessagesWaiting(input_event_queue);
+}
+
+size_t hid_report_queue_waiting(void)
+{
+    if (hid_report_queue == NULL) {
+        return 0;
+    }
+    return (size_t)uxQueueMessagesWaiting(hid_report_queue);
+}

--- a/03.firmware/04.integratedAPP/components/common/src/logger.c
+++ b/03.firmware/04.integratedAPP/components/common/src/logger.c
@@ -1,0 +1,38 @@
+/**
+ * @file logger.c
+ * @brief Handy Keyboard - ログ出力ラッパー実装
+ */
+
+#include "logger.h"
+#include <string.h>
+
+static const char *TAG = "LOGGER";
+
+esp_err_t logger_init(void)
+{
+    // デフォルトログレベル設定（sdkconfig.defaultsで制御）
+    ESP_LOGI(TAG, "Logger initialized");
+    ESP_LOGI(TAG, "Default log level: INFO");
+
+    return ESP_OK;
+}
+
+void logger_set_level(const char* tag, esp_log_level_t level)
+{
+    esp_log_level_set(tag, level);
+    ESP_LOGI(TAG, "Set log level for '%s' to %s",
+             tag, logger_level_to_string(level));
+}
+
+const char* logger_level_to_string(esp_log_level_t level)
+{
+    switch (level) {
+        case ESP_LOG_NONE:    return "NONE";
+        case ESP_LOG_ERROR:   return "ERROR";
+        case ESP_LOG_WARN:    return "WARN";
+        case ESP_LOG_INFO:    return "INFO";
+        case ESP_LOG_DEBUG:   return "DEBUG";
+        case ESP_LOG_VERBOSE: return "VERBOSE";
+        default:              return "UNKNOWN";
+    }
+}

--- a/03.firmware/04.integratedAPP/components/mjpeg_player/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/components/mjpeg_player/CMakeLists.txt
@@ -1,0 +1,6 @@
+idf_component_register(
+    SRCS "src/mjpeg_player.c"
+    INCLUDE_DIRS "include"
+    REQUIRES lvgl esp_driver_jpeg freertos
+    PRIV_REQUIRES bsp_jc4880p443c
+)

--- a/03.firmware/04.integratedAPP/components/mjpeg_player/include/mjpeg_player.h
+++ b/03.firmware/04.integratedAPP/components/mjpeg_player/include/mjpeg_player.h
@@ -1,0 +1,140 @@
+/**
+ * @file mjpeg_player.h
+ * @brief MJPEG Video Player for LVGL
+ *
+ * Plays MJPEG video files on LVGL image widgets using ESP32-P4 hardware JPEG decoder.
+ * MJPEG format: Concatenated JPEG frames (FFD8...FFD9 markers)
+ */
+
+#pragma once
+
+#include "esp_err.h"
+#include "lvgl.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** MJPEG player handle */
+typedef struct mjpeg_player *mjpeg_player_handle_t;
+
+/**
+ * @brief Cancellation check callback type
+ *
+ * This callback is called periodically during frame indexing (mjpeg_player_create).
+ * Return true to cancel the operation.
+ *
+ * @param user_data User data passed to the callback
+ * @return true to cancel, false to continue
+ */
+typedef bool (*mjpeg_cancel_check_cb_t)(void *user_data);
+
+/** MJPEG player configuration */
+typedef struct {
+    const char *file_path;      /**< Path to MJPEG file */
+    lv_obj_t *target_image;     /**< LVGL image widget to display frames */
+    uint16_t target_width;      /**< Target width for scaling (0 = original) */
+    uint16_t target_height;     /**< Target height for scaling (0 = original) */
+    uint8_t fps;                /**< Target FPS (1-60, default 30) */
+    bool loop;                  /**< Loop playback (default true) */
+    mjpeg_cancel_check_cb_t cancel_check; /**< Optional cancellation callback */
+    void *cancel_user_data;     /**< User data for cancel callback */
+} mjpeg_player_config_t;
+
+/** MJPEG player state */
+typedef enum {
+    MJPEG_STATE_IDLE,           /**< Not playing */
+    MJPEG_STATE_PLAYING,        /**< Currently playing */
+    MJPEG_STATE_PAUSED,         /**< Paused */
+    MJPEG_STATE_ERROR,          /**< Error occurred */
+} mjpeg_player_state_t;
+
+/**
+ * @brief Initialize the shared JPEG decoder at startup
+ *
+ * This should be called EARLY in system initialization (before display init),
+ * when internal DMA memory is still available.
+ *
+ * @return
+ *     - ESP_OK: Success
+ *     - ESP_ERR_NO_MEM: Not enough internal DMA memory
+ */
+esp_err_t mjpeg_player_init_shared_decoder(void);
+
+/**
+ * @brief Create MJPEG player instance
+ *
+ * @param config Player configuration
+ * @param[out] handle Pointer to store player handle
+ * @return
+ *     - ESP_OK: Success
+ *     - ESP_ERR_INVALID_ARG: Invalid arguments
+ *     - ESP_ERR_NO_MEM: Memory allocation failed
+ *     - ESP_ERR_NOT_FOUND: File not found
+ */
+esp_err_t mjpeg_player_create(const mjpeg_player_config_t *config, mjpeg_player_handle_t *handle);
+
+/**
+ * @brief Destroy MJPEG player instance
+ *
+ * @param handle Player handle
+ */
+void mjpeg_player_destroy(mjpeg_player_handle_t handle);
+
+/**
+ * @brief Start playback
+ *
+ * @param handle Player handle
+ * @return
+ *     - ESP_OK: Success
+ *     - ESP_ERR_INVALID_STATE: Already playing
+ */
+esp_err_t mjpeg_player_start(mjpeg_player_handle_t handle);
+
+/**
+ * @brief Stop playback
+ *
+ * @param handle Player handle
+ * @return ESP_OK always
+ */
+esp_err_t mjpeg_player_stop(mjpeg_player_handle_t handle);
+
+/**
+ * @brief Pause playback
+ *
+ * @param handle Player handle
+ * @return ESP_OK always
+ */
+esp_err_t mjpeg_player_pause(mjpeg_player_handle_t handle);
+
+/**
+ * @brief Resume playback
+ *
+ * @param handle Player handle
+ * @return ESP_OK always
+ */
+esp_err_t mjpeg_player_resume(mjpeg_player_handle_t handle);
+
+/**
+ * @brief Get current playback state
+ *
+ * @param handle Player handle
+ * @return Current state
+ */
+mjpeg_player_state_t mjpeg_player_get_state(mjpeg_player_handle_t handle);
+
+/**
+ * @brief Get playback progress
+ *
+ * @param handle Player handle
+ * @param[out] current_frame Current frame number
+ * @param[out] total_frames Total number of frames (0 if unknown)
+ */
+void mjpeg_player_get_progress(mjpeg_player_handle_t handle, uint32_t *current_frame, uint32_t *total_frames);
+
+#ifdef __cplusplus
+}
+#endif

--- a/03.firmware/04.integratedAPP/components/mjpeg_player/src/mjpeg_player.c
+++ b/03.firmware/04.integratedAPP/components/mjpeg_player/src/mjpeg_player.c
@@ -30,7 +30,7 @@ static const char *TAG = "MJPEG_PLAYER";
 
 /** Task configuration */
 #define MJPEG_TASK_STACK_SIZE  8192
-#define MJPEG_TASK_PRIORITY    5
+#define MJPEG_TASK_PRIORITY    7  // Higher priority for smoother playback
 
 // ============================================================================
 // Shared JPEG Decoder (Singleton)

--- a/03.firmware/04.integratedAPP/components/mjpeg_player/src/mjpeg_player.c
+++ b/03.firmware/04.integratedAPP/components/mjpeg_player/src/mjpeg_player.c
@@ -1,0 +1,759 @@
+/**
+ * @file mjpeg_player.c
+ * @brief MJPEG Video Player Implementation using ESP32-P4 Hardware JPEG Decoder
+ *
+ * Uses a dedicated FreeRTOS task for frame decoding to avoid blocking.
+ */
+
+#include "mjpeg_player.h"
+#include "esp_log.h"
+#include "esp_heap_caps.h"
+#include "driver/jpeg_decode.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+#include "bsp/jc4880p443c.h"  // For bsp_display_lock/unlock
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *TAG = "MJPEG_PLAYER";
+
+/** JPEG markers */
+#define JPEG_SOI_MARKER 0xFFD8  /**< Start Of Image */
+#define JPEG_EOI_MARKER 0xFFD9  /**< End Of Image */
+
+/** Buffer sizes */
+#define MJPEG_READ_BUFFER_SIZE (64 * 1024)   /**< 64KB read buffer for faster scanning */
+#define MJPEG_MAX_FRAME_SIZE   (256 * 1024)  /**< 256KB max frame size */
+#define MJPEG_MAX_FRAMES       5000          /**< Maximum frames to index (~3.5 min at 24fps) */
+
+/** Task configuration */
+#define MJPEG_TASK_STACK_SIZE  8192
+#define MJPEG_TASK_PRIORITY    5
+
+// ============================================================================
+// Shared JPEG Decoder (Singleton)
+// ============================================================================
+// ESP32-P4 hardware JPEG decoder requires internal DMA memory for rxlink.
+// To avoid running out of internal memory, we share a single decoder instance.
+
+static jpeg_decoder_handle_t s_shared_jpeg_decoder = NULL;
+static SemaphoreHandle_t s_decoder_mutex = NULL;
+static int s_decoder_ref_count = 0;
+
+esp_err_t mjpeg_player_init_shared_decoder(void)
+{
+    if (s_decoder_mutex == NULL) {
+        s_decoder_mutex = xSemaphoreCreateMutex();
+        if (s_decoder_mutex == NULL) {
+            ESP_LOGE(TAG, "Failed to create decoder mutex");
+            return ESP_ERR_NO_MEM;
+        }
+    }
+
+    if (s_shared_jpeg_decoder != NULL) {
+        ESP_LOGD(TAG, "Shared JPEG decoder already initialized");
+        return ESP_OK;
+    }
+
+    // Log available internal DMA memory before allocation
+    size_t free_dma = heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
+    ESP_LOGD(TAG, "Free internal DMA memory before JPEG init: %u bytes", free_dma);
+
+    jpeg_decode_engine_cfg_t decode_eng_cfg = {
+        .timeout_ms = 100,
+    };
+    esp_err_t ret = jpeg_new_decoder_engine(&decode_eng_cfg, &s_shared_jpeg_decoder);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to create shared JPEG decoder: %s", esp_err_to_name(ret));
+        ESP_LOGE(TAG, "Free internal DMA memory: %u bytes (may need more for rxlink)", free_dma);
+        return ret;
+    }
+
+    ESP_LOGD(TAG, "Shared JPEG decoder created successfully");
+    return ESP_OK;
+}
+
+/**
+ * @brief Get or create the shared JPEG decoder instance
+ * @return ESP_OK on success
+ */
+static esp_err_t get_shared_decoder(jpeg_decoder_handle_t *decoder)
+{
+    if (s_decoder_mutex == NULL) {
+        s_decoder_mutex = xSemaphoreCreateMutex();
+        if (s_decoder_mutex == NULL) {
+            return ESP_ERR_NO_MEM;
+        }
+    }
+
+    if (xSemaphoreTake(s_decoder_mutex, pdMS_TO_TICKS(1000)) != pdTRUE) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    esp_err_t ret = ESP_OK;
+
+    if (s_shared_jpeg_decoder == NULL) {
+        // Try to create the decoder (should have been initialized early)
+        ESP_LOGW(TAG, "Shared JPEG decoder not pre-initialized, creating now");
+
+        size_t free_dma = heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
+        ESP_LOGW(TAG, "Free internal DMA memory: %u bytes", free_dma);
+
+        jpeg_decode_engine_cfg_t decode_eng_cfg = {
+            .timeout_ms = 100,
+        };
+        ret = jpeg_new_decoder_engine(&decode_eng_cfg, &s_shared_jpeg_decoder);
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to create shared JPEG decoder: %s", esp_err_to_name(ret));
+            xSemaphoreGive(s_decoder_mutex);
+            return ret;
+        }
+        ESP_LOGD(TAG, "Shared JPEG decoder created (late init)");
+    }
+
+    s_decoder_ref_count++;
+    *decoder = s_shared_jpeg_decoder;
+
+    xSemaphoreGive(s_decoder_mutex);
+    return ESP_OK;
+}
+
+/**
+ * @brief Release reference to shared JPEG decoder
+ */
+static void release_shared_decoder(void)
+{
+    if (s_decoder_mutex == NULL) {
+        return;
+    }
+
+    if (xSemaphoreTake(s_decoder_mutex, pdMS_TO_TICKS(1000)) != pdTRUE) {
+        return;
+    }
+
+    s_decoder_ref_count--;
+
+    // Don't delete the decoder even when ref_count reaches 0
+    // Keep it alive to avoid re-allocation issues
+
+    xSemaphoreGive(s_decoder_mutex);
+}
+
+/**
+ * @brief Lock shared decoder for exclusive use during decode operation
+ */
+static bool lock_shared_decoder(uint32_t timeout_ms)
+{
+    if (s_decoder_mutex == NULL) {
+        return false;
+    }
+    return xSemaphoreTake(s_decoder_mutex, pdMS_TO_TICKS(timeout_ms)) == pdTRUE;
+}
+
+/**
+ * @brief Unlock shared decoder
+ */
+static void unlock_shared_decoder(void)
+{
+    if (s_decoder_mutex != NULL) {
+        xSemaphoreGive(s_decoder_mutex);
+    }
+}
+
+/** Frame index entry for seeking */
+typedef struct {
+    uint32_t offset;            /**< File offset */
+    uint32_t size;              /**< Frame size in bytes */
+} mjpeg_frame_index_t;
+
+/** MJPEG player internal structure */
+struct mjpeg_player {
+    FILE *file;                 /**< File handle */
+    char *file_path;            /**< File path copy */
+    lv_obj_t *target_image;     /**< Target LVGL image widget */
+
+    uint16_t target_width;      /**< Target width */
+    uint16_t target_height;     /**< Target height */
+    uint8_t fps;                /**< Target FPS */
+    bool loop;                  /**< Loop playback */
+
+    mjpeg_player_state_t state; /**< Current state */
+
+    // Cancellation callback
+    mjpeg_cancel_check_cb_t cancel_check; /**< Cancellation check callback */
+    void *cancel_user_data;     /**< User data for cancel callback */
+
+    // Playback task
+    TaskHandle_t playback_task; /**< Playback task handle */
+    volatile bool task_running; /**< Task running flag */
+
+    // Hardware JPEG decoder (reference to shared decoder)
+    jpeg_decoder_handle_t jpeg_decoder; /**< Reference to shared JPEG decoder */
+
+    // Input buffer (JPEG data)
+    uint8_t *jpeg_buffer;       /**< JPEG input buffer (DMA capable) */
+    size_t jpeg_buffer_size;    /**< JPEG buffer allocated size */
+
+    // Output buffer (decoded RGB)
+    uint8_t *rgb_buffer;        /**< RGB output buffer (DMA capable) */
+    size_t rgb_buffer_size;     /**< RGB buffer allocated size */
+
+    lv_image_dsc_t image_dsc;   /**< LVGL image descriptor */
+
+    mjpeg_frame_index_t *frame_index; /**< Frame index array */
+    uint32_t frame_count;       /**< Total number of frames */
+    uint32_t current_frame;     /**< Current frame index */
+
+    SemaphoreHandle_t mutex;    /**< Thread safety mutex */
+
+    bool owns_decoder;          /**< True if this player owns a decoder reference */
+};
+
+// ============================================================================
+// Internal Helpers
+// ============================================================================
+
+/**
+ * @brief Fast frame indexing using buffered reads
+ */
+static esp_err_t index_frames_fast(struct mjpeg_player *player)
+{
+    fseek(player->file, 0, SEEK_END);
+    long file_size = ftell(player->file);
+    fseek(player->file, 0, SEEK_SET);
+
+    ESP_LOGD(TAG, "Indexing MJPEG file (%ld bytes)...", file_size);
+
+    // Allocate temporary read buffer from PSRAM (prefer) or internal RAM
+    uint8_t *buffer = heap_caps_malloc(MJPEG_READ_BUFFER_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (buffer == NULL) {
+        // Fallback to internal RAM if PSRAM not available
+        buffer = heap_caps_malloc(MJPEG_READ_BUFFER_SIZE, MALLOC_CAP_DEFAULT);
+    }
+    if (buffer == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate read buffer");
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Temporary frame index from PSRAM (will realloc to exact size later)
+    mjpeg_frame_index_t *temp_index = heap_caps_malloc(MJPEG_MAX_FRAMES * sizeof(mjpeg_frame_index_t),
+                                                        MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (temp_index == NULL) {
+        // Fallback to internal RAM
+        temp_index = malloc(MJPEG_MAX_FRAMES * sizeof(mjpeg_frame_index_t));
+    }
+    if (temp_index == NULL) {
+        free(buffer);
+        ESP_LOGE(TAG, "Failed to allocate temp index");
+        return ESP_ERR_NO_MEM;
+    }
+
+    uint32_t frame_count = 0;
+    uint32_t file_offset = 0;
+    bool in_frame = false;
+    uint32_t frame_start = 0;
+    uint8_t prev_byte = 0;
+
+    while (file_offset < (uint32_t)file_size && frame_count < MJPEG_MAX_FRAMES) {
+        size_t to_read = MJPEG_READ_BUFFER_SIZE;
+        if (file_offset + to_read > (uint32_t)file_size) {
+            to_read = file_size - file_offset;
+        }
+
+        size_t bytes_read = fread(buffer, 1, to_read, player->file);
+        if (bytes_read == 0) break;
+
+        for (size_t i = 0; i < bytes_read; i++) {
+            uint8_t curr_byte = buffer[i];
+            uint16_t marker = (prev_byte << 8) | curr_byte;
+
+            if (!in_frame) {
+                if (marker == JPEG_SOI_MARKER) {
+                    in_frame = true;
+                    frame_start = file_offset + i - 1;
+                }
+            } else {
+                if (marker == JPEG_EOI_MARKER) {
+                    uint32_t frame_end = file_offset + i + 1;
+                    temp_index[frame_count].offset = frame_start;
+                    temp_index[frame_count].size = frame_end - frame_start;
+                    frame_count++;
+                    in_frame = false;
+                }
+            }
+
+            prev_byte = curr_byte;
+        }
+
+        file_offset += bytes_read;
+
+        // Yield to avoid watchdog during large file scan
+        vTaskDelay(1);
+
+        // Check for cancellation
+        if (player->cancel_check != NULL && player->cancel_check(player->cancel_user_data)) {
+            ESP_LOGD(TAG, "Frame indexing cancelled at %lu/%ld bytes", (unsigned long)file_offset, file_size);
+            free(buffer);
+            free(temp_index);
+            return ESP_ERR_INVALID_STATE;  // Indicate cancellation
+        }
+    }
+
+    free(buffer);
+
+    if (frame_count == 0) {
+        free(temp_index);
+        ESP_LOGE(TAG, "No JPEG frames found in file");
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    // Shrink index to actual size (keep in PSRAM if that's where it was allocated)
+    mjpeg_frame_index_t *shrunk_index = heap_caps_realloc(temp_index,
+                                                          frame_count * sizeof(mjpeg_frame_index_t),
+                                                          MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (shrunk_index == NULL) {
+        // Try without PSRAM flag
+        shrunk_index = realloc(temp_index, frame_count * sizeof(mjpeg_frame_index_t));
+    }
+    player->frame_index = (shrunk_index != NULL) ? shrunk_index : temp_index;
+    player->frame_count = frame_count;
+
+    ESP_LOGI(TAG, "Found %lu frames in MJPEG file", (unsigned long)frame_count);
+
+    return ESP_OK;
+}
+
+/**
+ * @brief Decode and display a frame using hardware JPEG decoder
+ */
+static esp_err_t decode_and_display_frame(struct mjpeg_player *player, uint32_t frame_idx)
+{
+    if (frame_idx >= player->frame_count) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    mjpeg_frame_index_t *frame = &player->frame_index[frame_idx];
+
+    // Check frame size
+    if (frame->size > player->jpeg_buffer_size) {
+        ESP_LOGE(TAG, "Frame size %lu exceeds buffer %lu",
+                 (unsigned long)frame->size, (unsigned long)player->jpeg_buffer_size);
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Read JPEG frame data
+    fseek(player->file, frame->offset, SEEK_SET);
+    size_t bytes_read = fread(player->jpeg_buffer, 1, frame->size, player->file);
+    if (bytes_read != frame->size) {
+        ESP_LOGE(TAG, "Failed to read frame %lu", (unsigned long)frame_idx);
+        return ESP_FAIL;
+    }
+
+    // Get JPEG info to get actual dimensions
+    jpeg_decode_picture_info_t info;
+    esp_err_t ret = jpeg_decoder_get_info(player->jpeg_buffer, frame->size, &info);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to get JPEG info: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    if (frame_idx == 0) {
+        ESP_LOGD(TAG, "Frame size: %lux%lu", (unsigned long)info.width, (unsigned long)info.height);
+    }
+
+    // Check if output buffer is large enough for RGB565
+    // Hardware JPEG decoder aligns output to 16-byte boundaries
+    uint32_t aligned_width = (info.width + 15) & ~15;
+    uint32_t aligned_height = (info.height + 15) & ~15;
+    size_t required_size = aligned_width * aligned_height * 2;  // RGB565 = 2 bytes per pixel
+    if (required_size > player->rgb_buffer_size) {
+        ESP_LOGE(TAG, "RGB buffer too small: need %lu, have %lu",
+                 (unsigned long)required_size, (unsigned long)player->rgb_buffer_size);
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Decode JPEG to RGB565 using hardware decoder (matches display format)
+    jpeg_decode_cfg_t decode_cfg = {
+        .output_format = JPEG_DECODE_OUT_FORMAT_RGB565,
+        .rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_BGR,  // Display expects BGR order
+    };
+
+    // Lock shared decoder for exclusive access during decode
+    if (!lock_shared_decoder(100)) {
+        ESP_LOGW(TAG, "Decoder busy, skipping frame %lu", (unsigned long)frame_idx);
+        return ESP_ERR_TIMEOUT;
+    }
+
+    uint32_t out_size = 0;
+    ret = jpeg_decoder_process(
+        player->jpeg_decoder,
+        &decode_cfg,
+        player->jpeg_buffer,
+        frame->size,
+        player->rgb_buffer,
+        player->rgb_buffer_size,
+        &out_size
+    );
+
+    unlock_shared_decoder();
+
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Hardware JPEG decode failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    // Update LVGL image descriptor with decoded RGB565 data
+    player->image_dsc.header.cf = LV_COLOR_FORMAT_RGB565;
+    player->image_dsc.header.w = info.width;
+    player->image_dsc.header.h = info.height;
+    player->image_dsc.header.stride = info.width * 2;  // RGB565 = 2 bytes per pixel
+    player->image_dsc.data_size = out_size;
+    player->image_dsc.data = player->rgb_buffer;
+
+    // Update LVGL image (must be done with display lock)
+    if (bsp_display_lock(pdMS_TO_TICKS(50))) {
+        lv_image_set_src(player->target_image, &player->image_dsc);
+        lv_obj_invalidate(player->target_image);  // Force redraw
+        bsp_display_unlock();
+    } else {
+        ESP_LOGW(TAG, "Display lock timeout, skipping frame %lu", (unsigned long)frame_idx);
+    }
+
+    player->current_frame = frame_idx;
+
+    return ESP_OK;
+}
+
+/**
+ * @brief Playback task - runs frame decoding in a dedicated task
+ */
+static void mjpeg_playback_task(void *arg)
+{
+    struct mjpeg_player *player = (struct mjpeg_player *)arg;
+    TickType_t frame_delay = pdMS_TO_TICKS(1000 / player->fps);
+    TickType_t last_wake_time = xTaskGetTickCount();
+
+    ESP_LOGD(TAG, "Playback task started (delay=%lu ms)", (unsigned long)(1000 / player->fps));
+
+    while (player->task_running) {
+        if (player->state == MJPEG_STATE_PLAYING) {
+            if (xSemaphoreTake(player->mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+                uint32_t next_frame = player->current_frame + 1;
+
+                if (next_frame >= player->frame_count) {
+                    if (player->loop) {
+                        next_frame = 0;
+                    } else {
+                        player->state = MJPEG_STATE_IDLE;
+                        xSemaphoreGive(player->mutex);
+                        continue;
+                    }
+                }
+
+                decode_and_display_frame(player, next_frame);
+                xSemaphoreGive(player->mutex);
+            }
+
+            // Wait for next frame time
+            vTaskDelayUntil(&last_wake_time, frame_delay);
+        } else if (player->state == MJPEG_STATE_PAUSED) {
+            // Just wait when paused
+            vTaskDelay(pdMS_TO_TICKS(100));
+            last_wake_time = xTaskGetTickCount();
+        } else {
+            // Idle state - wait and check periodically
+            vTaskDelay(pdMS_TO_TICKS(100));
+            last_wake_time = xTaskGetTickCount();
+        }
+    }
+
+    ESP_LOGD(TAG, "Playback task stopped");
+    vTaskDelete(NULL);
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+esp_err_t mjpeg_player_create(const mjpeg_player_config_t *config, mjpeg_player_handle_t *handle)
+{
+    if (config == NULL || handle == NULL || config->file_path == NULL || config->target_image == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    *handle = NULL;
+    esp_err_t ret = ESP_ERR_NO_MEM;
+
+    // Allocate player structure (calloc zeros all pointers for safe cleanup)
+    struct mjpeg_player *player = calloc(1, sizeof(struct mjpeg_player));
+    if (player == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate player structure");
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Copy file path
+    player->file_path = strdup(config->file_path);
+    if (player->file_path == NULL) {
+        goto cleanup;
+    }
+
+    // Open file
+    player->file = fopen(config->file_path, "rb");
+    if (player->file == NULL) {
+        ESP_LOGE(TAG, "Failed to open file: %s", config->file_path);
+        ret = ESP_ERR_NOT_FOUND;
+        goto cleanup;
+    }
+
+    // Create mutex
+    player->mutex = xSemaphoreCreateMutex();
+    if (player->mutex == NULL) {
+        goto cleanup;
+    }
+
+    // Initialize settings
+    player->target_image = config->target_image;
+    player->target_width = config->target_width > 0 ? config->target_width : 480;
+    player->target_height = config->target_height > 0 ? config->target_height : 800;
+    player->fps = (config->fps > 0 && config->fps <= 60) ? config->fps : 24;
+    player->loop = config->loop;
+    player->state = MJPEG_STATE_IDLE;
+    player->cancel_check = config->cancel_check;
+    player->cancel_user_data = config->cancel_user_data;
+
+    // Get reference to shared JPEG decoder (singleton pattern)
+    ret = get_shared_decoder(&player->jpeg_decoder);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to get shared JPEG decoder: %s", esp_err_to_name(ret));
+        goto cleanup;
+    }
+    player->owns_decoder = true;
+
+    // Allocate DMA-capable JPEG input buffer
+    jpeg_decode_memory_alloc_cfg_t tx_mem_cfg = {
+        .buffer_direction = JPEG_DEC_ALLOC_INPUT_BUFFER,
+    };
+    player->jpeg_buffer = (uint8_t *)jpeg_alloc_decoder_mem(MJPEG_MAX_FRAME_SIZE, &tx_mem_cfg, &player->jpeg_buffer_size);
+    if (player->jpeg_buffer == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate JPEG input buffer");
+        ret = ESP_ERR_NO_MEM;
+        goto cleanup;
+    }
+
+    // Allocate DMA-capable RGB output buffer (RGB565: 2 bytes per pixel)
+    // Use larger dimension to handle both landscape and portrait videos
+    // Also align to 16-byte boundaries as required by hardware JPEG decoder
+    size_t max_dim = (player->target_width > player->target_height) ? player->target_width : player->target_height;
+    size_t aligned_dim = (max_dim + 15) & ~15;  // Align to 16 bytes
+    size_t rgb_size = aligned_dim * aligned_dim * 2;  // RGB565 = 2 bytes per pixel
+    jpeg_decode_memory_alloc_cfg_t rx_mem_cfg = {
+        .buffer_direction = JPEG_DEC_ALLOC_OUTPUT_BUFFER,
+    };
+    player->rgb_buffer = (uint8_t *)jpeg_alloc_decoder_mem(rgb_size, &rx_mem_cfg, &player->rgb_buffer_size);
+    if (player->rgb_buffer == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate RGB output buffer");
+        ret = ESP_ERR_NO_MEM;
+        goto cleanup;
+    }
+
+    ESP_LOGD(TAG, "Allocated buffers: JPEG=%lu, RGB=%lu",
+             (unsigned long)player->jpeg_buffer_size, (unsigned long)player->rgb_buffer_size);
+
+    // Index frames (using fast buffered method)
+    ret = index_frames_fast(player);
+    if (ret != ESP_OK) {
+        goto cleanup;
+    }
+
+    // Create playback task
+    player->task_running = true;
+    BaseType_t task_ret = xTaskCreate(
+        mjpeg_playback_task,
+        "mjpeg_play",
+        MJPEG_TASK_STACK_SIZE,
+        player,
+        MJPEG_TASK_PRIORITY,
+        &player->playback_task
+    );
+
+    if (task_ret != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create playback task");
+        player->task_running = false;
+        ret = ESP_ERR_NO_MEM;
+        goto cleanup;
+    }
+
+    ESP_LOGI(TAG, "MJPEG player created: %s (%lu frames, %d FPS, HW decoder)",
+             config->file_path, (unsigned long)player->frame_count, player->fps);
+
+    *handle = player;
+    return ESP_OK;
+
+cleanup:
+    // Free resources in reverse allocation order (NULL-safe)
+    free(player->frame_index);
+    free(player->rgb_buffer);
+    free(player->jpeg_buffer);
+    if (player->owns_decoder) {
+        release_shared_decoder();
+    }
+    if (player->mutex != NULL) {
+        vSemaphoreDelete(player->mutex);
+    }
+    if (player->file != NULL) {
+        fclose(player->file);
+    }
+    free(player->file_path);
+    free(player);
+    return ret;
+}
+
+void mjpeg_player_destroy(mjpeg_player_handle_t handle)
+{
+    if (handle == NULL) {
+        return;
+    }
+
+    struct mjpeg_player *player = handle;
+
+    // Stop task
+    player->task_running = false;
+    player->state = MJPEG_STATE_IDLE;
+    vTaskDelay(pdMS_TO_TICKS(200));  // Wait for task to finish
+
+    // Free resources
+    if (player->mutex != NULL) {
+        vSemaphoreDelete(player->mutex);
+    }
+
+    if (player->frame_index != NULL) {
+        free(player->frame_index);
+    }
+
+    if (player->rgb_buffer != NULL) {
+        free(player->rgb_buffer);
+    }
+
+    if (player->jpeg_buffer != NULL) {
+        free(player->jpeg_buffer);
+    }
+
+    // Release reference to shared decoder (don't delete it)
+    if (player->owns_decoder) {
+        release_shared_decoder();
+        player->owns_decoder = false;
+    }
+
+    if (player->file != NULL) {
+        fclose(player->file);
+    }
+
+    if (player->file_path != NULL) {
+        free(player->file_path);
+    }
+
+    free(player);
+
+    ESP_LOGD(TAG, "MJPEG player destroyed");
+}
+
+esp_err_t mjpeg_player_start(mjpeg_player_handle_t handle)
+{
+    if (handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct mjpeg_player *player = handle;
+
+    if (player->state == MJPEG_STATE_PLAYING) {
+        return ESP_OK;  // Already playing
+    }
+
+    if (xSemaphoreTake(player->mutex, pdMS_TO_TICKS(100)) != pdTRUE) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    // Display first frame
+    player->current_frame = 0;
+    esp_err_t ret = decode_and_display_frame(player, 0);
+    if (ret != ESP_OK) {
+        xSemaphoreGive(player->mutex);
+        return ret;
+    }
+
+    player->state = MJPEG_STATE_PLAYING;
+    xSemaphoreGive(player->mutex);
+
+    ESP_LOGD(TAG, "MJPEG playback started");
+    return ESP_OK;
+}
+
+esp_err_t mjpeg_player_stop(mjpeg_player_handle_t handle)
+{
+    if (handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct mjpeg_player *player = handle;
+
+    player->state = MJPEG_STATE_IDLE;
+    player->current_frame = 0;
+
+    ESP_LOGD(TAG, "MJPEG playback stopped");
+    return ESP_OK;
+}
+
+esp_err_t mjpeg_player_pause(mjpeg_player_handle_t handle)
+{
+    if (handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct mjpeg_player *player = handle;
+
+    if (player->state == MJPEG_STATE_PLAYING) {
+        player->state = MJPEG_STATE_PAUSED;
+        ESP_LOGD(TAG, "MJPEG playback paused at frame %lu", (unsigned long)player->current_frame);
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t mjpeg_player_resume(mjpeg_player_handle_t handle)
+{
+    if (handle == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    struct mjpeg_player *player = handle;
+
+    if (player->state == MJPEG_STATE_PAUSED) {
+        player->state = MJPEG_STATE_PLAYING;
+        ESP_LOGD(TAG, "MJPEG playback resumed");
+    }
+
+    return ESP_OK;
+}
+
+mjpeg_player_state_t mjpeg_player_get_state(mjpeg_player_handle_t handle)
+{
+    if (handle == NULL) {
+        return MJPEG_STATE_ERROR;
+    }
+
+    return handle->state;
+}
+
+void mjpeg_player_get_progress(mjpeg_player_handle_t handle, uint32_t *current_frame, uint32_t *total_frames)
+{
+    if (handle == NULL) {
+        if (current_frame) *current_frame = 0;
+        if (total_frames) *total_frames = 0;
+        return;
+    }
+
+    if (current_frame) *current_frame = handle->current_frame;
+    if (total_frames) *total_frames = handle->frame_count;
+}

--- a/03.firmware/04.integratedAPP/components/sdcard/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/components/sdcard/CMakeLists.txt
@@ -1,0 +1,6 @@
+idf_component_register(
+    SRCS "src/sdcard.c"
+    INCLUDE_DIRS "include"
+    REQUIRES nvs_flash
+    PRIV_REQUIRES bsp_jc4880p443c
+)

--- a/03.firmware/04.integratedAPP/components/sdcard/include/sdcard.h
+++ b/03.firmware/04.integratedAPP/components/sdcard/include/sdcard.h
@@ -1,0 +1,142 @@
+/**
+ * @file sdcard.h
+ * @brief SD Card management for background images
+ *
+ * Provides file listing, state management, and NVS persistence
+ * for background image settings.
+ */
+
+#pragma once
+
+#include "esp_err.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief SD card states
+ */
+typedef enum {
+    SDCARD_STATE_NOT_PRESENT,   /**< SD card not inserted or mount failed */
+    SDCARD_STATE_MOUNTED,       /**< SD card mounted and ready */
+    SDCARD_STATE_ERROR,         /**< SD card error occurred */
+} sdcard_state_t;
+
+/**
+ * @brief File information structure
+ */
+typedef struct {
+    char filename[64];          /**< File name only */
+    char full_path[128];        /**< Full path for LVGL */
+} sdcard_file_t;
+
+/** Maximum number of background files to list */
+#define SDCARD_MAX_FILES        32
+
+/** Background images directory */
+#define SDCARD_BG_DIR           "/sdcard/background"
+
+/** Special value for "no background" */
+#define SDCARD_BG_NONE          ""
+
+/**
+ * @brief Initialize SD card management
+ *
+ * Mounts SD card using BSP and initializes NVS namespace.
+ *
+ * @return ESP_OK on success, error code otherwise
+ */
+esp_err_t sdcard_init(void);
+
+/**
+ * @brief Get current SD card state
+ *
+ * @return Current state (mounted, not present, or error)
+ */
+sdcard_state_t sdcard_get_state(void);
+
+/**
+ * @brief Check if SD card is available for use
+ *
+ * @return true if mounted and ready
+ */
+bool sdcard_is_available(void);
+
+/**
+ * @brief List background image files from SD card
+ *
+ * Lists files in /sdcard/background/ directory.
+ * Supports common image formats (jpg, jpeg, png, bmp).
+ *
+ * @param[out] files Array to store file information
+ * @param[in]  max_files Maximum files to retrieve
+ * @param[out] count Actual number of files found
+ * @return ESP_OK on success
+ */
+esp_err_t sdcard_list_backgrounds(sdcard_file_t *files, size_t max_files, size_t *count);
+
+/**
+ * @brief Refresh SD card (remount and rescan)
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t sdcard_refresh(void);
+
+/**
+ * @brief Format SD card as FAT32
+ *
+ * WARNING: All data will be erased!
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t sdcard_format(void);
+
+/**
+ * @brief Get saved touchpad background path
+ *
+ * @param[out] path Buffer to store path
+ * @param[in]  len  Buffer length
+ * @return ESP_OK if path exists, ESP_ERR_NOT_FOUND if not set
+ */
+esp_err_t sdcard_get_touchpad_bg(char *path, size_t len);
+
+/**
+ * @brief Set touchpad background path (persisted to NVS)
+ *
+ * @param[in] path Full path to image, or SDCARD_BG_NONE to clear
+ * @return ESP_OK on success
+ */
+esp_err_t sdcard_set_touchpad_bg(const char *path);
+
+/**
+ * @brief Get saved clock background path
+ *
+ * @param[out] path Buffer to store path
+ * @param[in]  len  Buffer length
+ * @return ESP_OK if path exists, ESP_ERR_NOT_FOUND if not set
+ */
+esp_err_t sdcard_get_clock_bg(char *path, size_t len);
+
+/**
+ * @brief Set clock background path (persisted to NVS)
+ *
+ * @param[in] path Full path to image, or SDCARD_BG_NONE to clear
+ * @return ESP_OK on success
+ */
+esp_err_t sdcard_set_clock_bg(const char *path);
+
+/**
+ * @brief Get SD card capacity information
+ *
+ * @param[out] total_mb Total capacity in MB
+ * @param[out] used_mb  Used space in MB
+ * @return ESP_OK on success
+ */
+esp_err_t sdcard_get_capacity(uint32_t *total_mb, uint32_t *used_mb);
+
+#ifdef __cplusplus
+}
+#endif

--- a/03.firmware/04.integratedAPP/components/sdcard/src/sdcard.c
+++ b/03.firmware/04.integratedAPP/components/sdcard/src/sdcard.c
@@ -39,11 +39,13 @@ static bool is_image_file(const char *filename)
         return false;
     }
 
-    // Supported formats (LVGL can decode these)
+    // Supported formats (LVGL can decode these + MJPEG video)
     return (strcasecmp(ext, ".jpg") == 0 ||
             strcasecmp(ext, ".jpeg") == 0 ||
             strcasecmp(ext, ".png") == 0 ||
-            strcasecmp(ext, ".bmp") == 0);
+            strcasecmp(ext, ".bmp") == 0 ||
+            strcasecmp(ext, ".mjpg") == 0 ||
+            strcasecmp(ext, ".mjpeg") == 0);
 }
 
 /**

--- a/03.firmware/04.integratedAPP/components/sdcard/src/sdcard.c
+++ b/03.firmware/04.integratedAPP/components/sdcard/src/sdcard.c
@@ -1,0 +1,313 @@
+/**
+ * @file sdcard.c
+ * @brief SD Card management implementation
+ */
+
+#include "sdcard.h"
+#include "bsp/jc4880p443c.h"
+#include "esp_log.h"
+#include "nvs_flash.h"
+#include "nvs.h"
+#include <dirent.h>
+#include <sys/stat.h>
+#include <string.h>
+#include <strings.h>  // strcasecmp
+
+static const char *TAG = "SDCARD";
+
+// NVS namespace and keys
+#define NVS_NAMESPACE       "bg_settings"
+#define NVS_KEY_TOUCHPAD    "bg_touchpad"
+#define NVS_KEY_CLOCK       "bg_clock"
+
+// State
+static sdcard_state_t s_state = SDCARD_STATE_NOT_PRESENT;
+static nvs_handle_t s_nvs_handle = 0;
+static bool s_nvs_opened = false;
+
+/**
+ * @brief Check if filename has supported image extension
+ */
+static bool is_image_file(const char *filename)
+{
+    if (!filename || strlen(filename) < 5) {
+        return false;
+    }
+
+    const char *ext = strrchr(filename, '.');
+    if (!ext) {
+        return false;
+    }
+
+    // Supported formats (LVGL can decode these)
+    return (strcasecmp(ext, ".jpg") == 0 ||
+            strcasecmp(ext, ".jpeg") == 0 ||
+            strcasecmp(ext, ".png") == 0 ||
+            strcasecmp(ext, ".bmp") == 0);
+}
+
+/**
+ * @brief Open NVS namespace for settings
+ */
+static esp_err_t open_nvs(void)
+{
+    if (s_nvs_opened) {
+        return ESP_OK;
+    }
+
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &s_nvs_handle);
+    if (ret == ESP_OK) {
+        s_nvs_opened = true;
+    } else {
+        ESP_LOGE(TAG, "Failed to open NVS namespace: %s", esp_err_to_name(ret));
+    }
+    return ret;
+}
+
+esp_err_t sdcard_init(void)
+{
+    ESP_LOGI(TAG, "Initializing SD card management...");
+
+    // Try to mount SD card using BSP
+    esp_err_t ret = bsp_sdcard_mount();
+    if (ret == ESP_OK) {
+        s_state = SDCARD_STATE_MOUNTED;
+        ESP_LOGI(TAG, "SD card mounted at %s", BSP_SD_MOUNT_POINT);
+
+        // Create background directory if it doesn't exist
+        struct stat st;
+        if (stat(SDCARD_BG_DIR, &st) != 0) {
+            if (mkdir(SDCARD_BG_DIR, 0755) == 0) {
+                ESP_LOGI(TAG, "Created background directory: %s", SDCARD_BG_DIR);
+            } else {
+                ESP_LOGW(TAG, "Failed to create background directory");
+            }
+        }
+    } else {
+        s_state = SDCARD_STATE_NOT_PRESENT;
+        ESP_LOGW(TAG, "SD card not available: %s", esp_err_to_name(ret));
+    }
+
+    // Open NVS for settings (independent of SD card)
+    open_nvs();
+
+    return ESP_OK;  // Always return OK - SD card is optional
+}
+
+sdcard_state_t sdcard_get_state(void)
+{
+    return s_state;
+}
+
+bool sdcard_is_available(void)
+{
+    return s_state == SDCARD_STATE_MOUNTED;
+}
+
+esp_err_t sdcard_list_backgrounds(sdcard_file_t *files, size_t max_files, size_t *count)
+{
+    if (!files || !count) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    *count = 0;
+
+    if (s_state != SDCARD_STATE_MOUNTED) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    DIR *dir = opendir(SDCARD_BG_DIR);
+    if (!dir) {
+        ESP_LOGW(TAG, "Cannot open background directory: %s", SDCARD_BG_DIR);
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != NULL && *count < max_files) {
+        // Skip directories and hidden files
+        if (entry->d_type == DT_DIR || entry->d_name[0] == '.') {
+            continue;
+        }
+
+        // Check if it's an image file
+        if (!is_image_file(entry->d_name)) {
+            continue;
+        }
+
+        // Store file info
+        strncpy(files[*count].filename, entry->d_name, sizeof(files[*count].filename) - 1);
+        files[*count].filename[sizeof(files[*count].filename) - 1] = '\0';
+
+        snprintf(files[*count].full_path, sizeof(files[*count].full_path),
+                 "%s/%s", SDCARD_BG_DIR, entry->d_name);
+
+        ESP_LOGD(TAG, "Found: %s", files[*count].filename);
+        (*count)++;
+    }
+
+    closedir(dir);
+
+    ESP_LOGI(TAG, "Found %zu background images", *count);
+    return ESP_OK;
+}
+
+esp_err_t sdcard_refresh(void)
+{
+    ESP_LOGI(TAG, "Refreshing SD card...");
+
+    // Unmount if mounted
+    if (s_state == SDCARD_STATE_MOUNTED) {
+        bsp_sdcard_unmount();
+        s_state = SDCARD_STATE_NOT_PRESENT;
+    }
+
+    // Try to remount
+    esp_err_t ret = bsp_sdcard_mount();
+    if (ret == ESP_OK) {
+        s_state = SDCARD_STATE_MOUNTED;
+        ESP_LOGI(TAG, "SD card refreshed successfully");
+    } else {
+        s_state = SDCARD_STATE_NOT_PRESENT;
+        ESP_LOGW(TAG, "SD card not available after refresh");
+    }
+
+    return ret;
+}
+
+esp_err_t sdcard_format(void)
+{
+    ESP_LOGW(TAG, "Formatting SD card (all data will be lost!)");
+
+    // Check if SD card is currently mounted
+    if (s_state != SDCARD_STATE_MOUNTED) {
+        ESP_LOGW(TAG, "SD card not mounted, trying to mount first...");
+        esp_err_t mount_ret = bsp_sdcard_mount();
+        if (mount_ret != ESP_OK) {
+            ESP_LOGE(TAG, "Cannot format: SD card mount failed (%s)", esp_err_to_name(mount_ret));
+            ESP_LOGE(TAG, "Please check if SD card is inserted properly");
+            s_state = SDCARD_STATE_NOT_PRESENT;
+            return mount_ret;
+        }
+        s_state = SDCARD_STATE_MOUNTED;
+    }
+
+    esp_err_t ret = bsp_sdcard_format();
+    if (ret == ESP_OK) {
+        s_state = SDCARD_STATE_MOUNTED;
+        ESP_LOGI(TAG, "SD card formatted successfully");
+
+        // Recreate background directory
+        mkdir(SDCARD_BG_DIR, 0755);
+    } else {
+        s_state = SDCARD_STATE_ERROR;
+        ESP_LOGE(TAG, "Format failed: %s", esp_err_to_name(ret));
+    }
+
+    return ret;
+}
+
+esp_err_t sdcard_get_touchpad_bg(char *path, size_t len)
+{
+    if (!path || len == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!s_nvs_opened && open_nvs() != ESP_OK) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    size_t required_size = len;
+    esp_err_t ret = nvs_get_str(s_nvs_handle, NVS_KEY_TOUCHPAD, path, &required_size);
+    if (ret == ESP_ERR_NVS_NOT_FOUND) {
+        path[0] = '\0';
+    }
+    return ret;
+}
+
+esp_err_t sdcard_set_touchpad_bg(const char *path)
+{
+    if (!s_nvs_opened && open_nvs() != ESP_OK) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    esp_err_t ret;
+    if (path && path[0] != '\0') {
+        ret = nvs_set_str(s_nvs_handle, NVS_KEY_TOUCHPAD, path);
+    } else {
+        ret = nvs_erase_key(s_nvs_handle, NVS_KEY_TOUCHPAD);
+        if (ret == ESP_ERR_NVS_NOT_FOUND) {
+            ret = ESP_OK;  // Key didn't exist, that's fine
+        }
+    }
+
+    if (ret == ESP_OK) {
+        ret = nvs_commit(s_nvs_handle);
+    }
+
+    ESP_LOGI(TAG, "Touchpad background set: %s", path ? path : "(none)");
+    return ret;
+}
+
+esp_err_t sdcard_get_clock_bg(char *path, size_t len)
+{
+    if (!path || len == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (!s_nvs_opened && open_nvs() != ESP_OK) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    size_t required_size = len;
+    esp_err_t ret = nvs_get_str(s_nvs_handle, NVS_KEY_CLOCK, path, &required_size);
+    if (ret == ESP_ERR_NVS_NOT_FOUND) {
+        path[0] = '\0';
+    }
+    return ret;
+}
+
+esp_err_t sdcard_set_clock_bg(const char *path)
+{
+    if (!s_nvs_opened && open_nvs() != ESP_OK) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    esp_err_t ret;
+    if (path && path[0] != '\0') {
+        ret = nvs_set_str(s_nvs_handle, NVS_KEY_CLOCK, path);
+    } else {
+        ret = nvs_erase_key(s_nvs_handle, NVS_KEY_CLOCK);
+        if (ret == ESP_ERR_NVS_NOT_FOUND) {
+            ret = ESP_OK;
+        }
+    }
+
+    if (ret == ESP_OK) {
+        ret = nvs_commit(s_nvs_handle);
+    }
+
+    ESP_LOGI(TAG, "Clock background set: %s", path ? path : "(none)");
+    return ret;
+}
+
+esp_err_t sdcard_get_capacity(uint32_t *total_mb, uint32_t *used_mb)
+{
+    if (!total_mb || !used_mb) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (s_state != SDCARD_STATE_MOUNTED || !bsp_sdcard) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    // Get card info from BSP global
+    uint64_t total_bytes = (uint64_t)bsp_sdcard->csd.capacity * bsp_sdcard->csd.sector_size;
+    *total_mb = (uint32_t)(total_bytes / (1024 * 1024));
+
+    // Get used space via FATFS (simplified - just report total for now)
+    // A full implementation would use f_getfree()
+    *used_mb = 0;  // TODO: implement actual used space calculation
+
+    ESP_LOGD(TAG, "SD card capacity: %lu MB", (unsigned long)*total_mb);
+    return ESP_OK;
+}

--- a/03.firmware/04.integratedAPP/components/ui/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/components/ui/CMakeLists.txt
@@ -9,6 +9,6 @@ file(GLOB_RECURSE UI_SOURCES
 idf_component_register(
     SRCS ${UI_SOURCES}
     INCLUDE_DIRS "." "screens" "fonts" "images" "components"
-    REQUIRES lvgl ble_hid sdcard esp_driver_jpeg
+    REQUIRES lvgl ble_hid sdcard esp_driver_jpeg mjpeg_player
     PRIV_REQUIRES bsp_jc4880p443c
 )

--- a/03.firmware/04.integratedAPP/components/ui/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/components/ui/CMakeLists.txt
@@ -9,6 +9,6 @@ file(GLOB_RECURSE UI_SOURCES
 idf_component_register(
     SRCS ${UI_SOURCES}
     INCLUDE_DIRS "." "screens" "fonts" "images" "components"
-    REQUIRES lvgl ble_hid
+    REQUIRES lvgl ble_hid sdcard esp_driver_jpeg
     PRIV_REQUIRES bsp_jc4880p443c
 )

--- a/03.firmware/04.integratedAPP/components/ui/ui_background.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_background.c
@@ -3,11 +3,13 @@
  * @brief Background image management implementation
  *
  * Uses ESP32-P4 hardware JPEG decoder for fast JPEG loading.
+ * Supports MJPEG video backgrounds using the mjpeg_player component.
  */
 
 #include "ui_background.h"
 #include "ui.h"
 #include "sdcard.h"
+#include "mjpeg_player.h"
 #include "bsp/jc4880p443c.h"
 #include "esp_log.h"
 #include "esp_heap_caps.h"
@@ -99,6 +101,18 @@ static bool is_jpeg_file(const char *filename)
     if (ext == NULL) return false;
     ext++;
     return (strcasecmp(ext, "jpg") == 0 || strcasecmp(ext, "jpeg") == 0);
+}
+
+/**
+ * @brief Check if file is an MJPEG video
+ */
+static bool is_mjpeg_file(const char *filename)
+{
+    if (filename == NULL) return false;
+    const char *ext = strrchr(filename, '.');
+    if (ext == NULL) return false;
+    ext++;
+    return (strcasecmp(ext, "mjpg") == 0 || strcasecmp(ext, "mjpeg") == 0);
 }
 
 /**
@@ -297,6 +311,52 @@ static lv_obj_t *s_last_touchpad3 = NULL;
 static lv_obj_t *s_last_clock_panel = NULL;      // ui_Panel41 (background)
 static lv_obj_t *s_last_clock_container = NULL;  // ui_AnalogClockContainer (overlay)
 
+// MJPEG player handles
+static mjpeg_player_handle_t s_touchpad_mjpeg_player = NULL;
+static mjpeg_player_handle_t s_clock_mjpeg_player = NULL;
+
+// LVGL image widgets for MJPEG playback
+static lv_obj_t *s_touchpad_mjpeg_image = NULL;
+static lv_obj_t *s_clock_mjpeg_image = NULL;
+
+/**
+ * @brief Stop and destroy MJPEG player for touchpad
+ */
+static void stop_touchpad_mjpeg(void)
+{
+    if (s_touchpad_mjpeg_player != NULL) {
+        mjpeg_player_stop(s_touchpad_mjpeg_player);
+        mjpeg_player_destroy(s_touchpad_mjpeg_player);
+        s_touchpad_mjpeg_player = NULL;
+    }
+    if (s_touchpad_mjpeg_image != NULL) {
+        if (bsp_display_lock(100)) {
+            lv_obj_delete(s_touchpad_mjpeg_image);
+            bsp_display_unlock();
+        }
+        s_touchpad_mjpeg_image = NULL;
+    }
+}
+
+/**
+ * @brief Stop and destroy MJPEG player for clock
+ */
+static void stop_clock_mjpeg(void)
+{
+    if (s_clock_mjpeg_player != NULL) {
+        mjpeg_player_stop(s_clock_mjpeg_player);
+        mjpeg_player_destroy(s_clock_mjpeg_player);
+        s_clock_mjpeg_player = NULL;
+    }
+    if (s_clock_mjpeg_image != NULL) {
+        if (bsp_display_lock(100)) {
+            lv_obj_delete(s_clock_mjpeg_image);
+            bsp_display_unlock();
+        }
+        s_clock_mjpeg_image = NULL;
+    }
+}
+
 // External UI objects (from SquareLine generated code)
 extern lv_obj_t *ui_TouchAndScrollPanel;    // JPKeyboardScreen
 extern lv_obj_t *ui_TouchAndScrollPanel1;   // AtoZKeyboardScreen
@@ -339,6 +399,9 @@ static void apply_bg_to_panel_with_path(lv_obj_t *panel, const char *lvgl_path)
 
 esp_err_t ui_bg_apply_to_touchpad(const char *path)
 {
+    // Stop any existing MJPEG player
+    stop_touchpad_mjpeg();
+
     // Free previous image data
     free_touchpad_image();
 
@@ -352,10 +415,16 @@ esp_err_t ui_bg_apply_to_touchpad(const char *path)
 
     // Decode image if path provided
     bool use_hw_jpeg = false;
+    bool use_mjpeg = false;
     static char lvgl_path[140] = {0};  // Extra space for "S:" prefix
+    lvgl_path[0] = '\0';
 
     if (s_touchpad_bg_path[0] != '\0') {
-        if (is_jpeg_file(s_touchpad_bg_path)) {
+        if (is_mjpeg_file(s_touchpad_bg_path)) {
+            // Use MJPEG player for video backgrounds
+            use_mjpeg = true;
+            ESP_LOGI(TAG, "Touchpad: using MJPEG player");
+        } else if (is_jpeg_file(s_touchpad_bg_path)) {
             // Use hardware JPEG decoder
             esp_err_t ret = hw_jpeg_decode_file(s_touchpad_bg_path, &s_touchpad_image_dsc, &s_touchpad_image_data);
             if (ret == ESP_OK) {
@@ -372,9 +441,59 @@ esp_err_t ui_bg_apply_to_touchpad(const char *path)
         }
     }
 
-    // Apply to all touchpad panels (they may not exist yet)
+    // Apply to touchpad panel (use first available panel for MJPEG)
     if (bsp_display_lock(100)) {
-        if (use_hw_jpeg) {
+        if (use_mjpeg) {
+            // Create MJPEG player for the first touchpad panel
+            lv_obj_t *target_panel = ui_TouchAndScrollPanel;
+            if (target_panel == NULL) target_panel = ui_TouchAndScrollPanel1;
+            if (target_panel == NULL) target_panel = ui_TouchAndScrollPanel2;
+
+            if (target_panel != NULL) {
+                // Clear any existing background
+                apply_bg_to_panel_with_dsc(target_panel, NULL);
+
+                // Create lv_image widget for MJPEG playback
+                s_touchpad_mjpeg_image = lv_image_create(target_panel);
+                if (s_touchpad_mjpeg_image != NULL) {
+                    lv_obj_set_size(s_touchpad_mjpeg_image, LV_PCT(100), LV_PCT(100));
+                    lv_obj_center(s_touchpad_mjpeg_image);
+                    lv_image_set_inner_align(s_touchpad_mjpeg_image, LV_IMAGE_ALIGN_STRETCH);
+
+                    bsp_display_unlock();
+
+                    // Create MJPEG player (this may take time for indexing)
+                    mjpeg_player_config_t cfg = {
+                        .file_path = s_touchpad_bg_path,
+                        .target_image = s_touchpad_mjpeg_image,
+                        .target_width = 480,
+                        .target_height = 370,
+                        .fps = 24,
+                        .loop = true,
+                        .cancel_check = NULL,
+                        .cancel_user_data = NULL,
+                    };
+                    esp_err_t ret = mjpeg_player_create(&cfg, &s_touchpad_mjpeg_player);
+                    if (ret == ESP_OK) {
+                        mjpeg_player_start(s_touchpad_mjpeg_player);
+                        ESP_LOGI(TAG, "Touchpad MJPEG player started");
+                    } else {
+                        ESP_LOGE(TAG, "Failed to create MJPEG player: %s", esp_err_to_name(ret));
+                        // Clean up on failure
+                        if (bsp_display_lock(100)) {
+                            lv_obj_delete(s_touchpad_mjpeg_image);
+                            s_touchpad_mjpeg_image = NULL;
+                            bsp_display_unlock();
+                        }
+                    }
+
+                    // Re-acquire lock for tracking
+                    if (!bsp_display_lock(100)) {
+                        goto done;
+                    }
+                }
+            }
+        } else if (use_hw_jpeg) {
             apply_bg_to_panel_with_dsc(ui_TouchAndScrollPanel, &s_touchpad_image_dsc);
             apply_bg_to_panel_with_dsc(ui_TouchAndScrollPanel1, &s_touchpad_image_dsc);
             apply_bg_to_panel_with_dsc(ui_TouchAndScrollPanel2, &s_touchpad_image_dsc);
@@ -397,12 +516,16 @@ esp_err_t ui_bg_apply_to_touchpad(const char *path)
         bsp_display_unlock();
     }
 
+done:
     ESP_LOGI(TAG, "Touchpad background: %s", s_touchpad_bg_path[0] ? s_touchpad_bg_path : "(none)");
     return ESP_OK;
 }
 
 esp_err_t ui_bg_apply_to_clock(const char *path)
 {
+    // Stop any existing MJPEG player
+    stop_clock_mjpeg();
+
     // Free previous image data
     free_clock_image();
 
@@ -416,11 +539,16 @@ esp_err_t ui_bg_apply_to_clock(const char *path)
 
     // Decode image if path provided
     bool use_hw_jpeg = false;
+    bool use_mjpeg = false;
     static char lvgl_path[140] = {0};  // Extra space for "S:" prefix
     lvgl_path[0] = '\0';
 
     if (s_clock_bg_path[0] != '\0') {
-        if (is_jpeg_file(s_clock_bg_path)) {
+        if (is_mjpeg_file(s_clock_bg_path)) {
+            // Use MJPEG player for video backgrounds
+            use_mjpeg = true;
+            ESP_LOGI(TAG, "Clock: using MJPEG player");
+        } else if (is_jpeg_file(s_clock_bg_path)) {
             // Use hardware JPEG decoder
             esp_err_t ret = hw_jpeg_decode_file(s_clock_bg_path, &s_clock_image_dsc, &s_clock_image_data);
             if (ret == ESP_OK) {
@@ -440,7 +568,53 @@ esp_err_t ui_bg_apply_to_clock(const char *path)
     if (bsp_display_lock(100)) {
         // Apply background to ui_Panel41 (full-screen panel behind clock)
         if (ui_Panel41) {
-            if (use_hw_jpeg) {
+            if (use_mjpeg) {
+                // Clear any existing background
+                lv_obj_set_style_bg_image_src(ui_Panel41, NULL,
+                                              LV_PART_MAIN | LV_STATE_DEFAULT);
+
+                // Create lv_image widget for MJPEG playback
+                s_clock_mjpeg_image = lv_image_create(ui_Panel41);
+                if (s_clock_mjpeg_image != NULL) {
+                    lv_obj_set_size(s_clock_mjpeg_image, LV_PCT(100), LV_PCT(100));
+                    lv_obj_center(s_clock_mjpeg_image);
+                    lv_image_set_inner_align(s_clock_mjpeg_image, LV_IMAGE_ALIGN_STRETCH);
+                    // Send to back so clock face is on top
+                    lv_obj_move_to_index(s_clock_mjpeg_image, 0);
+
+                    bsp_display_unlock();
+
+                    // Create MJPEG player (this may take time for indexing)
+                    mjpeg_player_config_t cfg = {
+                        .file_path = s_clock_bg_path,
+                        .target_image = s_clock_mjpeg_image,
+                        .target_width = 480,
+                        .target_height = 800,
+                        .fps = 24,
+                        .loop = true,
+                        .cancel_check = NULL,
+                        .cancel_user_data = NULL,
+                    };
+                    esp_err_t ret = mjpeg_player_create(&cfg, &s_clock_mjpeg_player);
+                    if (ret == ESP_OK) {
+                        mjpeg_player_start(s_clock_mjpeg_player);
+                        ESP_LOGI(TAG, "Clock MJPEG player started");
+                    } else {
+                        ESP_LOGE(TAG, "Failed to create MJPEG player: %s", esp_err_to_name(ret));
+                        // Clean up on failure
+                        if (bsp_display_lock(100)) {
+                            lv_obj_delete(s_clock_mjpeg_image);
+                            s_clock_mjpeg_image = NULL;
+                            bsp_display_unlock();
+                        }
+                    }
+
+                    // Re-acquire lock for rest of function
+                    if (!bsp_display_lock(100)) {
+                        goto clock_done;
+                    }
+                }
+            } else if (use_hw_jpeg) {
                 lv_obj_set_style_bg_image_src(ui_Panel41, &s_clock_image_dsc,
                                               LV_PART_MAIN | LV_STATE_DEFAULT);
                 lv_obj_set_style_bg_image_opa(ui_Panel41, LV_OPA_COVER,
@@ -470,6 +644,7 @@ esp_err_t ui_bg_apply_to_clock(const char *path)
         bsp_display_unlock();
     }
 
+clock_done:
     ESP_LOGI(TAG, "Clock background: %s", s_clock_bg_path[0] ? s_clock_bg_path : "(default)");
     return ESP_OK;
 }

--- a/03.firmware/04.integratedAPP/components/ui/ui_background.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_background.c
@@ -1,0 +1,580 @@
+/**
+ * @file ui_background.c
+ * @brief Background image management implementation
+ *
+ * Uses ESP32-P4 hardware JPEG decoder for fast JPEG loading.
+ */
+
+#include "ui_background.h"
+#include "ui.h"
+#include "sdcard.h"
+#include "bsp/jc4880p443c.h"
+#include "esp_log.h"
+#include "esp_heap_caps.h"
+#include "driver/jpeg_decode.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include <string.h>
+#include <stdio.h>
+#include <strings.h>
+
+static const char *TAG = "UI_BG";
+
+// LVGL filesystem drive letter for POSIX (CONFIG_LV_FS_POSIX_LETTER=83='S')
+#define LVGL_FS_PREFIX "S:"
+
+// Max JPEG file size for hardware decoder (256KB)
+#define MAX_JPEG_FILE_SIZE (256 * 1024)
+
+// ============================================================================
+// Shared JPEG Decoder (Singleton)
+// ============================================================================
+// ESP32-P4 hardware JPEG decoder requires internal DMA memory for rxlink.
+// To avoid running out of internal memory, we share a single decoder instance.
+
+static jpeg_decoder_handle_t s_shared_jpeg_decoder = NULL;
+static SemaphoreHandle_t s_decoder_mutex = NULL;
+
+esp_err_t ui_bg_init_jpeg_decoder(void)
+{
+    if (s_decoder_mutex == NULL) {
+        s_decoder_mutex = xSemaphoreCreateMutex();
+        if (s_decoder_mutex == NULL) {
+            ESP_LOGE(TAG, "Failed to create decoder mutex");
+            return ESP_ERR_NO_MEM;
+        }
+    }
+
+    if (s_shared_jpeg_decoder != NULL) {
+        ESP_LOGD(TAG, "Shared JPEG decoder already initialized");
+        return ESP_OK;
+    }
+
+    // Log available internal DMA memory before allocation
+    size_t free_dma = heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
+    ESP_LOGI(TAG, "Free internal DMA memory before JPEG init: %u bytes", free_dma);
+
+    jpeg_decode_engine_cfg_t decode_eng_cfg = {
+        .timeout_ms = 100,
+    };
+    esp_err_t ret = jpeg_new_decoder_engine(&decode_eng_cfg, &s_shared_jpeg_decoder);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to create shared JPEG decoder: %s", esp_err_to_name(ret));
+        ESP_LOGE(TAG, "Free internal DMA memory: %u bytes (may need more for rxlink)", free_dma);
+        return ret;
+    }
+
+    ESP_LOGI(TAG, "Hardware JPEG decoder initialized successfully");
+    return ESP_OK;
+}
+
+/**
+ * @brief Lock shared decoder for exclusive use during decode operation
+ */
+static bool lock_jpeg_decoder(uint32_t timeout_ms)
+{
+    if (s_decoder_mutex == NULL) {
+        return false;
+    }
+    return xSemaphoreTake(s_decoder_mutex, pdMS_TO_TICKS(timeout_ms)) == pdTRUE;
+}
+
+/**
+ * @brief Unlock shared decoder
+ */
+static void unlock_jpeg_decoder(void)
+{
+    if (s_decoder_mutex != NULL) {
+        xSemaphoreGive(s_decoder_mutex);
+    }
+}
+
+/**
+ * @brief Check if file is a JPEG
+ */
+static bool is_jpeg_file(const char *filename)
+{
+    if (filename == NULL) return false;
+    const char *ext = strrchr(filename, '.');
+    if (ext == NULL) return false;
+    ext++;
+    return (strcasecmp(ext, "jpg") == 0 || strcasecmp(ext, "jpeg") == 0);
+}
+
+/**
+ * @brief Decode JPEG file using hardware decoder
+ *
+ * @param[in] file_path Path to JPEG file (POSIX path, not LVGL path)
+ * @param[out] image_dsc LVGL image descriptor (caller must free data with sdcard_free_background)
+ * @return ESP_OK on success
+ */
+static esp_err_t hw_jpeg_decode_file(const char *file_path, lv_image_dsc_t *image_dsc, uint8_t **out_data)
+{
+    if (file_path == NULL || image_dsc == NULL || out_data == NULL) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    *out_data = NULL;
+    memset(image_dsc, 0, sizeof(*image_dsc));
+
+    if (s_shared_jpeg_decoder == NULL) {
+        ESP_LOGE(TAG, "JPEG decoder not initialized - call ui_bg_init_jpeg_decoder() first");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    esp_err_t ret;
+
+    // Open file
+    FILE *file = fopen(file_path, "rb");
+    if (file == NULL) {
+        ESP_LOGE(TAG, "Failed to open file: %s", file_path);
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    // Get file size
+    fseek(file, 0, SEEK_END);
+    long file_size = ftell(file);
+    fseek(file, 0, SEEK_SET);
+
+    if (file_size <= 0 || file_size > MAX_JPEG_FILE_SIZE) {
+        ESP_LOGE(TAG, "Invalid file size: %ld (max %d)", file_size, MAX_JPEG_FILE_SIZE);
+        fclose(file);
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    // Allocate DMA-capable input buffer
+    jpeg_decode_memory_alloc_cfg_t tx_mem_cfg = {
+        .buffer_direction = JPEG_DEC_ALLOC_INPUT_BUFFER,
+    };
+    size_t jpeg_buffer_size = 0;
+    uint8_t *jpeg_buffer = (uint8_t *)jpeg_alloc_decoder_mem(file_size, &tx_mem_cfg, &jpeg_buffer_size);
+    if (jpeg_buffer == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate JPEG input buffer");
+        fclose(file);
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Read file into buffer
+    size_t bytes_read = fread(jpeg_buffer, 1, file_size, file);
+    fclose(file);
+
+    if (bytes_read != (size_t)file_size) {
+        ESP_LOGE(TAG, "Failed to read file");
+        free(jpeg_buffer);
+        return ESP_FAIL;
+    }
+
+    // Get JPEG info
+    jpeg_decode_picture_info_t info;
+    ret = jpeg_decoder_get_info(jpeg_buffer, file_size, &info);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to get JPEG info: %s", esp_err_to_name(ret));
+        free(jpeg_buffer);
+        return ret;
+    }
+
+    ESP_LOGD(TAG, "JPEG info: %lux%lu", (unsigned long)info.width, (unsigned long)info.height);
+
+    // Hardware JPEG decoder aligns output to 16-byte boundaries
+    uint32_t aligned_width = (info.width + 15) & ~15;
+    uint32_t aligned_height = (info.height + 15) & ~15;
+
+    // Allocate DMA-capable output buffer (RGB565: 2 bytes per pixel)
+    size_t rgb_size = aligned_width * aligned_height * 2;
+    jpeg_decode_memory_alloc_cfg_t rx_mem_cfg = {
+        .buffer_direction = JPEG_DEC_ALLOC_OUTPUT_BUFFER,
+    };
+    size_t rgb_buffer_size = 0;
+    uint8_t *rgb_buffer = (uint8_t *)jpeg_alloc_decoder_mem(rgb_size, &rx_mem_cfg, &rgb_buffer_size);
+    if (rgb_buffer == NULL) {
+        ESP_LOGE(TAG, "Failed to allocate RGB output buffer");
+        free(jpeg_buffer);
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Decode JPEG to RGB565 (matches display format, no software conversion needed)
+    jpeg_decode_cfg_t decode_cfg = {
+        .output_format = JPEG_DECODE_OUT_FORMAT_RGB565,
+        .rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_BGR,  // Display expects BGR order
+    };
+
+    // Lock shared decoder for exclusive access
+    if (!lock_jpeg_decoder(1000)) {
+        ESP_LOGE(TAG, "Failed to lock shared decoder");
+        free(rgb_buffer);
+        free(jpeg_buffer);
+        return ESP_ERR_TIMEOUT;
+    }
+
+    uint32_t out_size = 0;
+    ret = jpeg_decoder_process(
+        s_shared_jpeg_decoder,
+        &decode_cfg,
+        jpeg_buffer,
+        file_size,
+        rgb_buffer,
+        rgb_buffer_size,
+        &out_size
+    );
+
+    unlock_jpeg_decoder();
+
+    // Free input buffer
+    free(jpeg_buffer);
+
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "JPEG decode failed: %s", esp_err_to_name(ret));
+        free(rgb_buffer);
+        return ret;
+    }
+
+    // Set up LVGL image descriptor
+    image_dsc->header.cf = LV_COLOR_FORMAT_RGB565;
+    image_dsc->header.w = info.width;
+    image_dsc->header.h = info.height;
+    image_dsc->header.stride = info.width * 2;  // RGB565 = 2 bytes per pixel
+    image_dsc->data_size = out_size;
+    image_dsc->data = rgb_buffer;
+
+    *out_data = rgb_buffer;
+
+    ESP_LOGI(TAG, "JPEG decoded (HW): %s (%ux%u, %lu bytes)",
+             file_path, info.width, info.height, (unsigned long)out_size);
+
+    return ESP_OK;
+}
+
+// Cache current background paths (POSIX paths)
+static char s_touchpad_bg_path[128] = {0};
+static char s_clock_bg_path[128] = {0};
+
+// Decoded image data for hardware-decoded JPEGs
+static uint8_t *s_touchpad_image_data = NULL;
+static lv_image_dsc_t s_touchpad_image_dsc = {0};
+static uint8_t *s_clock_image_data = NULL;
+static lv_image_dsc_t s_clock_image_dsc = {0};
+
+/**
+ * @brief Convert POSIX path to LVGL path with drive letter prefix
+ * @param posix_path Path like "/sdcard/background/image.jpg"
+ * @param lvgl_path Output buffer for path like "S:/sdcard/background/image.jpg"
+ * @param lvgl_path_size Size of output buffer
+ */
+static void posix_to_lvgl_path(const char *posix_path, char *lvgl_path, size_t lvgl_path_size)
+{
+    if (!posix_path || !lvgl_path || lvgl_path_size < 4) {
+        if (lvgl_path && lvgl_path_size > 0) lvgl_path[0] = '\0';
+        return;
+    }
+    snprintf(lvgl_path, lvgl_path_size, "%s%s", LVGL_FS_PREFIX, posix_path);
+}
+
+/**
+ * @brief Free decoded image data
+ */
+static void free_touchpad_image(void)
+{
+    if (s_touchpad_image_data != NULL) {
+        free(s_touchpad_image_data);
+        s_touchpad_image_data = NULL;
+    }
+    memset(&s_touchpad_image_dsc, 0, sizeof(s_touchpad_image_dsc));
+}
+
+static void free_clock_image(void)
+{
+    if (s_clock_image_data != NULL) {
+        free(s_clock_image_data);
+        s_clock_image_data = NULL;
+    }
+    memset(&s_clock_image_dsc, 0, sizeof(s_clock_image_dsc));
+}
+
+// Track which screen objects we've applied backgrounds to
+static lv_obj_t *s_last_touchpad1 = NULL;
+static lv_obj_t *s_last_touchpad2 = NULL;
+static lv_obj_t *s_last_touchpad3 = NULL;
+static lv_obj_t *s_last_clock_panel = NULL;      // ui_Panel41 (background)
+static lv_obj_t *s_last_clock_container = NULL;  // ui_AnalogClockContainer (overlay)
+
+// External UI objects (from SquareLine generated code)
+extern lv_obj_t *ui_TouchAndScrollPanel;    // JPKeyboardScreen
+extern lv_obj_t *ui_TouchAndScrollPanel1;   // AtoZKeyboardScreen
+extern lv_obj_t *ui_TouchAndScrollPanel2;   // CursorScreen
+extern lv_obj_t *ui_Panel41;                // AnalogClock full-screen panel (for background)
+extern lv_obj_t *ui_AnalogClockContainer;   // Analog clock face (overlay)
+
+// Default clock background image (embedded asset)
+LV_IMG_DECLARE(ui_img_717184261);
+
+/**
+ * @brief Apply background image to a single panel using image descriptor
+ */
+static void apply_bg_to_panel_with_dsc(lv_obj_t *panel, const lv_image_dsc_t *dsc)
+{
+    if (!panel) return;
+
+    if (dsc && dsc->data) {
+        lv_obj_set_style_bg_image_src(panel, dsc, LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_obj_set_style_bg_image_opa(panel, LV_OPA_COVER, LV_PART_MAIN | LV_STATE_DEFAULT);
+    } else {
+        lv_obj_set_style_bg_image_src(panel, NULL, LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+}
+
+/**
+ * @brief Apply background image to a single panel using LVGL file path
+ */
+static void apply_bg_to_panel_with_path(lv_obj_t *panel, const char *lvgl_path)
+{
+    if (!panel) return;
+
+    if (lvgl_path && lvgl_path[0] != '\0') {
+        lv_obj_set_style_bg_image_src(panel, lvgl_path, LV_PART_MAIN | LV_STATE_DEFAULT);
+        lv_obj_set_style_bg_image_opa(panel, LV_OPA_COVER, LV_PART_MAIN | LV_STATE_DEFAULT);
+    } else {
+        lv_obj_set_style_bg_image_src(panel, NULL, LV_PART_MAIN | LV_STATE_DEFAULT);
+    }
+}
+
+esp_err_t ui_bg_apply_to_touchpad(const char *path)
+{
+    // Free previous image data
+    free_touchpad_image();
+
+    // Cache the POSIX path
+    if (path && path[0] != '\0') {
+        strncpy(s_touchpad_bg_path, path, sizeof(s_touchpad_bg_path) - 1);
+        s_touchpad_bg_path[sizeof(s_touchpad_bg_path) - 1] = '\0';
+    } else {
+        s_touchpad_bg_path[0] = '\0';
+    }
+
+    // Decode image if path provided
+    bool use_hw_jpeg = false;
+    static char lvgl_path[140] = {0};  // Extra space for "S:" prefix
+
+    if (s_touchpad_bg_path[0] != '\0') {
+        if (is_jpeg_file(s_touchpad_bg_path)) {
+            // Use hardware JPEG decoder
+            esp_err_t ret = hw_jpeg_decode_file(s_touchpad_bg_path, &s_touchpad_image_dsc, &s_touchpad_image_data);
+            if (ret == ESP_OK) {
+                use_hw_jpeg = true;
+                ESP_LOGI(TAG, "Touchpad: using HW JPEG decoder");
+            } else {
+                ESP_LOGW(TAG, "HW JPEG decode failed, falling back to LVGL loader");
+                posix_to_lvgl_path(s_touchpad_bg_path, lvgl_path, sizeof(lvgl_path));
+            }
+        } else {
+            // Use LVGL file loader for PNG/BMP
+            posix_to_lvgl_path(s_touchpad_bg_path, lvgl_path, sizeof(lvgl_path));
+            ESP_LOGI(TAG, "Touchpad: using LVGL loader for %s", lvgl_path);
+        }
+    }
+
+    // Apply to all touchpad panels (they may not exist yet)
+    if (bsp_display_lock(100)) {
+        if (use_hw_jpeg) {
+            apply_bg_to_panel_with_dsc(ui_TouchAndScrollPanel, &s_touchpad_image_dsc);
+            apply_bg_to_panel_with_dsc(ui_TouchAndScrollPanel1, &s_touchpad_image_dsc);
+            apply_bg_to_panel_with_dsc(ui_TouchAndScrollPanel2, &s_touchpad_image_dsc);
+        } else if (lvgl_path[0] != '\0') {
+            apply_bg_to_panel_with_path(ui_TouchAndScrollPanel, lvgl_path);
+            apply_bg_to_panel_with_path(ui_TouchAndScrollPanel1, lvgl_path);
+            apply_bg_to_panel_with_path(ui_TouchAndScrollPanel2, lvgl_path);
+        } else {
+            // Clear backgrounds
+            apply_bg_to_panel_with_dsc(ui_TouchAndScrollPanel, NULL);
+            apply_bg_to_panel_with_dsc(ui_TouchAndScrollPanel1, NULL);
+            apply_bg_to_panel_with_dsc(ui_TouchAndScrollPanel2, NULL);
+        }
+
+        // Track which objects we applied to
+        s_last_touchpad1 = ui_TouchAndScrollPanel;
+        s_last_touchpad2 = ui_TouchAndScrollPanel1;
+        s_last_touchpad3 = ui_TouchAndScrollPanel2;
+
+        bsp_display_unlock();
+    }
+
+    ESP_LOGI(TAG, "Touchpad background: %s", s_touchpad_bg_path[0] ? s_touchpad_bg_path : "(none)");
+    return ESP_OK;
+}
+
+esp_err_t ui_bg_apply_to_clock(const char *path)
+{
+    // Free previous image data
+    free_clock_image();
+
+    // Cache the POSIX path
+    if (path && path[0] != '\0') {
+        strncpy(s_clock_bg_path, path, sizeof(s_clock_bg_path) - 1);
+        s_clock_bg_path[sizeof(s_clock_bg_path) - 1] = '\0';
+    } else {
+        s_clock_bg_path[0] = '\0';
+    }
+
+    // Decode image if path provided
+    bool use_hw_jpeg = false;
+    static char lvgl_path[140] = {0};  // Extra space for "S:" prefix
+    lvgl_path[0] = '\0';
+
+    if (s_clock_bg_path[0] != '\0') {
+        if (is_jpeg_file(s_clock_bg_path)) {
+            // Use hardware JPEG decoder
+            esp_err_t ret = hw_jpeg_decode_file(s_clock_bg_path, &s_clock_image_dsc, &s_clock_image_data);
+            if (ret == ESP_OK) {
+                use_hw_jpeg = true;
+                ESP_LOGI(TAG, "Clock: using HW JPEG decoder");
+            } else {
+                ESP_LOGW(TAG, "HW JPEG decode failed, falling back to LVGL loader");
+                posix_to_lvgl_path(s_clock_bg_path, lvgl_path, sizeof(lvgl_path));
+            }
+        } else {
+            // Use LVGL file loader for PNG/BMP
+            posix_to_lvgl_path(s_clock_bg_path, lvgl_path, sizeof(lvgl_path));
+            ESP_LOGI(TAG, "Clock: using LVGL loader for %s", lvgl_path);
+        }
+    }
+
+    if (bsp_display_lock(100)) {
+        // Apply background to ui_Panel41 (full-screen panel behind clock)
+        if (ui_Panel41) {
+            if (use_hw_jpeg) {
+                lv_obj_set_style_bg_image_src(ui_Panel41, &s_clock_image_dsc,
+                                              LV_PART_MAIN | LV_STATE_DEFAULT);
+                lv_obj_set_style_bg_image_opa(ui_Panel41, LV_OPA_COVER,
+                                              LV_PART_MAIN | LV_STATE_DEFAULT);
+            } else if (lvgl_path[0] != '\0') {
+                lv_obj_set_style_bg_image_src(ui_Panel41, lvgl_path,
+                                              LV_PART_MAIN | LV_STATE_DEFAULT);
+                lv_obj_set_style_bg_image_opa(ui_Panel41, LV_OPA_COVER,
+                                              LV_PART_MAIN | LV_STATE_DEFAULT);
+            } else {
+                // Clear background
+                lv_obj_set_style_bg_image_src(ui_Panel41, NULL,
+                                              LV_PART_MAIN | LV_STATE_DEFAULT);
+            }
+            s_last_clock_panel = ui_Panel41;
+        }
+
+        // Keep clock face fully opaque (not semi-transparent)
+        if (ui_AnalogClockContainer) {
+            // Clock face image stays opaque regardless of background
+            lv_obj_set_style_bg_image_src(ui_AnalogClockContainer, &ui_img_717184261,
+                                          LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_set_style_bg_image_opa(ui_AnalogClockContainer, LV_OPA_COVER,
+                                          LV_PART_MAIN | LV_STATE_DEFAULT);
+            s_last_clock_container = ui_AnalogClockContainer;
+        }
+        bsp_display_unlock();
+    }
+
+    ESP_LOGI(TAG, "Clock background: %s", s_clock_bg_path[0] ? s_clock_bg_path : "(default)");
+    return ESP_OK;
+}
+
+esp_err_t ui_bg_clear_touchpad(void)
+{
+    return ui_bg_apply_to_touchpad(NULL);
+}
+
+esp_err_t ui_bg_clear_clock(void)
+{
+    return ui_bg_apply_to_clock(NULL);
+}
+
+void ui_bg_load_saved_settings(void)
+{
+    char path[128];
+
+    ESP_LOGI(TAG, "Loading saved background settings...");
+
+    // Load touchpad background
+    if (sdcard_get_touchpad_bg(path, sizeof(path)) == ESP_OK && path[0] != '\0') {
+        ESP_LOGI(TAG, "Restoring touchpad background: %s", path);
+        ui_bg_apply_to_touchpad(path);
+    }
+
+    // Load clock background
+    if (sdcard_get_clock_bg(path, sizeof(path)) == ESP_OK && path[0] != '\0') {
+        ESP_LOGI(TAG, "Restoring clock background: %s", path);
+        ui_bg_apply_to_clock(path);
+    }
+}
+
+void ui_bg_refresh_if_needed(void)
+{
+    // Check if screen objects have been recreated (different pointers)
+    // If so, reapply the cached backgrounds
+
+    bool need_touchpad_refresh = false;
+    bool need_clock_refresh = false;
+
+    // Check touchpads
+    if (ui_TouchAndScrollPanel && ui_TouchAndScrollPanel != s_last_touchpad1) {
+        need_touchpad_refresh = true;
+    }
+    if (ui_TouchAndScrollPanel1 && ui_TouchAndScrollPanel1 != s_last_touchpad2) {
+        need_touchpad_refresh = true;
+    }
+    if (ui_TouchAndScrollPanel2 && ui_TouchAndScrollPanel2 != s_last_touchpad3) {
+        need_touchpad_refresh = true;
+    }
+
+    // Check clock (both panel and container)
+    if (ui_Panel41 && ui_Panel41 != s_last_clock_panel) {
+        need_clock_refresh = true;
+    }
+    if (ui_AnalogClockContainer && ui_AnalogClockContainer != s_last_clock_container) {
+        need_clock_refresh = true;
+    }
+
+    // Reapply touchpad if needed (no lock needed - called from LVGL timer context)
+    if (need_touchpad_refresh && s_touchpad_bg_path[0] != '\0') {
+        // Use decoded image if available, otherwise use LVGL path
+        if (s_touchpad_image_data != NULL) {
+            apply_bg_to_panel_with_dsc(ui_TouchAndScrollPanel, &s_touchpad_image_dsc);
+            apply_bg_to_panel_with_dsc(ui_TouchAndScrollPanel1, &s_touchpad_image_dsc);
+            apply_bg_to_panel_with_dsc(ui_TouchAndScrollPanel2, &s_touchpad_image_dsc);
+        } else {
+            char lvgl_path[140];
+            posix_to_lvgl_path(s_touchpad_bg_path, lvgl_path, sizeof(lvgl_path));
+            apply_bg_to_panel_with_path(ui_TouchAndScrollPanel, lvgl_path);
+            apply_bg_to_panel_with_path(ui_TouchAndScrollPanel1, lvgl_path);
+            apply_bg_to_panel_with_path(ui_TouchAndScrollPanel2, lvgl_path);
+        }
+        s_last_touchpad1 = ui_TouchAndScrollPanel;
+        s_last_touchpad2 = ui_TouchAndScrollPanel1;
+        s_last_touchpad3 = ui_TouchAndScrollPanel2;
+        ESP_LOGD(TAG, "Refreshed touchpad backgrounds");
+    }
+
+    // Reapply clock if needed
+    if (need_clock_refresh && s_clock_bg_path[0] != '\0') {
+        // Apply background to Panel41
+        if (ui_Panel41) {
+            if (s_clock_image_data != NULL) {
+                lv_obj_set_style_bg_image_src(ui_Panel41, &s_clock_image_dsc,
+                                              LV_PART_MAIN | LV_STATE_DEFAULT);
+            } else {
+                char lvgl_path[140];
+                posix_to_lvgl_path(s_clock_bg_path, lvgl_path, sizeof(lvgl_path));
+                lv_obj_set_style_bg_image_src(ui_Panel41, lvgl_path,
+                                              LV_PART_MAIN | LV_STATE_DEFAULT);
+            }
+            lv_obj_set_style_bg_image_opa(ui_Panel41, LV_OPA_COVER,
+                                          LV_PART_MAIN | LV_STATE_DEFAULT);
+            s_last_clock_panel = ui_Panel41;
+        }
+        // Keep clock face fully opaque
+        if (ui_AnalogClockContainer) {
+            lv_obj_set_style_bg_image_src(ui_AnalogClockContainer, &ui_img_717184261,
+                                          LV_PART_MAIN | LV_STATE_DEFAULT);
+            lv_obj_set_style_bg_image_opa(ui_AnalogClockContainer, LV_OPA_COVER,
+                                          LV_PART_MAIN | LV_STATE_DEFAULT);
+            s_last_clock_container = ui_AnalogClockContainer;
+        }
+        ESP_LOGD(TAG, "Refreshed clock background");
+    }
+}

--- a/03.firmware/04.integratedAPP/components/ui/ui_background.h
+++ b/03.firmware/04.integratedAPP/components/ui/ui_background.h
@@ -1,0 +1,82 @@
+/**
+ * @file ui_background.h
+ * @brief Background image management for UI screens
+ *
+ * Applies background images from SD card to touchpad panels
+ * and analog clock container. Uses ESP32-P4 hardware JPEG decoder
+ * for fast JPEG loading.
+ */
+
+#pragma once
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize the shared hardware JPEG decoder
+ *
+ * This should be called EARLY in system initialization (before display init),
+ * when internal DMA memory is still available. The hardware JPEG decoder
+ * requires internal DMA-capable memory for its descriptor chains.
+ *
+ * @return
+ *     - ESP_OK: Success
+ *     - ESP_ERR_NO_MEM: Not enough internal DMA memory
+ */
+esp_err_t ui_bg_init_jpeg_decoder(void);
+
+/**
+ * @brief Apply background image to all touchpad panels
+ *
+ * Sets the same background image on JPKeyboard, AtoZ, and Cursor
+ * screen touchpad panels.
+ *
+ * @param[in] path Full path to image file, or NULL to clear
+ * @return ESP_OK on success
+ */
+esp_err_t ui_bg_apply_to_touchpad(const char *path);
+
+/**
+ * @brief Apply background image to analog clock
+ *
+ * @param[in] path Full path to image file, or NULL to use default
+ * @return ESP_OK on success
+ */
+esp_err_t ui_bg_apply_to_clock(const char *path);
+
+/**
+ * @brief Clear touchpad background (restore default)
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t ui_bg_clear_touchpad(void);
+
+/**
+ * @brief Clear clock background (restore default)
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t ui_bg_clear_clock(void);
+
+/**
+ * @brief Load and apply saved background settings from NVS
+ *
+ * Call this after UI and SD card are initialized to restore
+ * user's background preferences.
+ */
+void ui_bg_load_saved_settings(void);
+
+/**
+ * @brief Refresh backgrounds when screens are recreated
+ *
+ * Called by ui_navigation_update() to reapply backgrounds
+ * after screen transitions.
+ */
+void ui_bg_refresh_if_needed(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/03.firmware/04.integratedAPP/dependencies.lock
+++ b/03.firmware/04.integratedAPP/dependencies.lock
@@ -75,7 +75,7 @@ dependencies:
     version: 1.2.0
   espressif/esp_hosted:
     component_hash: 
-      f17471b7f596a520004415e607092a1ef41b280f79aee2fd11fb6f84a408155e
+      3790b0caf075d5119bdb98ee299a786c5ef43fc8a1d8da545c8731d7030035ec
     dependencies:
     - name: idf
       require: private
@@ -83,7 +83,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com/
       type: service
-    version: 2.9.3
+    version: 2.9.6
   espressif/esp_lcd_touch:
     component_hash: 
       3f85a7d95af876f1a6ecca8eb90a81614890d0f03a038390804e5a77e2caf862
@@ -220,6 +220,6 @@ direct_dependencies:
 - espressif/esp_hosted
 - espressif/esp_tinyusb
 - espressif/esp_wifi_remote
-manifest_hash: 936378c07434f814d8c8de4561786993a1e070b6fd9055e5ba92b00a02bbb9a5
+manifest_hash: f3d1da510af1cd0a73c92c73211b6e9af0dabdd0b7f24d651092ff3e67409711
 target: esp32p4
 version: 2.0.0

--- a/03.firmware/04.integratedAPP/main/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/main/CMakeLists.txt
@@ -12,4 +12,5 @@ idf_component_register(
         bsp_jc4880p443c
         ui
         ble_hid
+        sdcard
 )

--- a/03.firmware/04.integratedAPP/main/idf_component.yml
+++ b/03.firmware/04.integratedAPP/main/idf_component.yml
@@ -6,8 +6,9 @@ dependencies:
   espressif/esp_tinyusb: "^1.4.0"
 
   # WiFi/BLE support (ESP32-C6 via ESP-Hosted)
+  # Note: v2.9.6+ required for SD card coexistence fix
   espressif/esp_wifi_remote: "*"
-  espressif/esp_hosted: "*"
+  espressif/esp_hosted: "^2.9.6"
 
   # Board Support Package (includes LVGL, Display, Touch, Audio)
   bsp_jc4880p443c:

--- a/03.firmware/04.integratedAPP/main/main.c
+++ b/03.firmware/04.integratedAPP/main/main.c
@@ -40,6 +40,10 @@
 #include "ui_navigation.h"
 #include "ui_customization.h"
 
+// SD Card and Background management
+#include "sdcard.h"
+#include "ui_background.h"
+
 static const char *TAG = "HANDY_KEYBOARD";
 
 // LVGL display handle
@@ -175,6 +179,15 @@ void app_main(void)
     ESP_LOGI(TAG, "ESP32-P4 initialized");
     ESP_LOGI(TAG, "Free heap: %lu bytes", esp_get_free_heap_size());
 
+    // Initialize hardware JPEG decoder early (requires internal DMA memory)
+    // Must be done before display init consumes internal memory
+    ESP_LOGI(TAG, "Initializing hardware JPEG decoder...");
+    esp_err_t jpeg_ret = ui_bg_init_jpeg_decoder();
+    if (jpeg_ret != ESP_OK) {
+        ESP_LOGW(TAG, "Hardware JPEG decoder init failed: %s (will use software decoder)",
+                 esp_err_to_name(jpeg_ret));
+    }
+
     // Initialize BSP (Display, Touch, I2C, Audio)
     ESP_LOGI(TAG, "Initializing BSP...");
     g_display = bsp_display_start();
@@ -186,6 +199,21 @@ void app_main(void)
 
     // Turn on backlight
     bsp_display_backlight_on();
+
+    // Initialize BLE HID keyboard first (this ensures ESP-Hosted SDIO is fully configured
+    // before SD card mount, as both share the SDMMC host controller)
+    ESP_LOGI(TAG, "Initializing BLE HID...");
+    esp_err_t ble_ret = ble_hid_init();
+    if (ble_ret != ESP_OK) {
+        ESP_LOGW(TAG, "BLE HID init failed: %s", esp_err_to_name(ble_ret));
+    } else {
+        ESP_LOGI(TAG, "BLE HID initialized - device is now discoverable");
+    }
+
+    // Initialize SD card (optional - continues even if SD not present)
+    // Note: Must be after BLE HID init to avoid SDMMC host conflicts with ESP-Hosted
+    ESP_LOGI(TAG, "Initializing SD card...");
+    sdcard_init();
 
     // Initialize RTC using BSP I2C handle
     rtc_init();
@@ -201,18 +229,14 @@ void app_main(void)
         ESP_LOGE(TAG, "Failed to acquire display lock for UI creation");
     }
 
+    // Load saved background settings from NVS and apply to UI
+    if (sdcard_is_available()) {
+        ui_bg_load_saved_settings();
+    }
+
     // Start RTC update task (updates clock hands and header every second)
     if (g_rtc_initialized) {
         xTaskCreate(rtc_update_task, "rtc_update", 4096, NULL, 5, NULL);
-    }
-
-    // Initialize BLE HID keyboard
-    ESP_LOGI(TAG, "Initializing BLE HID...");
-    esp_err_t ble_ret = ble_hid_init();
-    if (ble_ret != ESP_OK) {
-        ESP_LOGW(TAG, "BLE HID init failed: %s", esp_err_to_name(ble_ret));
-    } else {
-        ESP_LOGI(TAG, "BLE HID initialized - device is now discoverable");
     }
 
     ESP_LOGI(TAG, "Initialization complete");


### PR DESCRIPTION
## Summary
- SDカードから画像（JPEG/PNG/BMP）を読み込み、タッチパッド背景・アナログ時計背景に設定可能
- MJPEG動画ファイルを背景アニメーションとして再生可能
- ESP32-P4ハードウェアJPEGデコーダによる高速デコード
- Settings画面でドロップダウンから背景画像を選択

## 機能
- `/sdcard/background/` ディレクトリから画像・動画を自動検出
- 対応フォーマット: `.jpg`, `.jpeg`, `.png`, `.bmp`, `.mjpg`, `.mjpeg`
- NVSによる設定永続化（再起動後も選択を保持）
- SDカードの再読み込み・フォーマット機能

## 既知の問題
- MJPEGフレームレートがkeyboard_2025より低い（Issue #15 で対応予定）
  - RGBバッファサイズの最適化が必要
  - Display lockタイムアウトによるフレームスキップ

## Test plan
- [ ] SDカードに`/background/`フォルダを作成し、画像を配置
- [ ] Settings画面でSDカードステータスが「Ready」と表示される
- [ ] タッチパッド/時計背景のドロップダウンで画像を選択
- [ ] 背景が即座に反映される
- [ ] 再起動後も設定が保持される
- [ ] MJPEGファイルが背景として再生される

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)