### PR TITLE
feat: アラーム機能とアラーム音の設定 (Issue #17)

### DIFF
--- a/03.firmware/04.integratedAPP/components/alarm/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/components/alarm/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Alarm component
+# Multiple alarm management with NVS storage
+
+idf_component_register(
+    SRCS
+        "src/alarm.c"
+    INCLUDE_DIRS
+        "include"
+    REQUIRES
+        freertos
+        esp_common
+        log
+        nvs_flash
+        audio_player
+)

--- a/03.firmware/04.integratedAPP/components/alarm/include/alarm.h
+++ b/03.firmware/04.integratedAPP/components/alarm/include/alarm.h
@@ -1,0 +1,190 @@
+/**
+ * @file alarm.h
+ * @brief Alarm Management API
+ *
+ * Provides multiple alarm support with NVS persistence,
+ * time checking, and audio playback triggers.
+ */
+
+#pragma once
+
+#include "esp_err.h"
+#include <stdbool.h>
+#include <stdint.h>
+#include <time.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Maximum number of alarms */
+#define ALARM_MAX_COUNT      8
+
+/** Maximum length of sound file path */
+#define ALARM_SOUND_PATH_LEN 64
+
+/** Default alarm sound path (when sound_path is empty) */
+#define ALARM_DEFAULT_SOUND  "/sdcard/sounds/alarm.wav"
+
+/** Snooze duration in minutes */
+#define ALARM_SNOOZE_MINUTES 5
+
+/**
+ * @brief Repeat day flags (bitmask)
+ */
+typedef enum {
+    ALARM_REPEAT_SUN = (1 << 0),  /**< Sunday */
+    ALARM_REPEAT_MON = (1 << 1),  /**< Monday */
+    ALARM_REPEAT_TUE = (1 << 2),  /**< Tuesday */
+    ALARM_REPEAT_WED = (1 << 3),  /**< Wednesday */
+    ALARM_REPEAT_THU = (1 << 4),  /**< Thursday */
+    ALARM_REPEAT_FRI = (1 << 5),  /**< Friday */
+    ALARM_REPEAT_SAT = (1 << 6),  /**< Saturday */
+
+    ALARM_REPEAT_WEEKDAYS = (ALARM_REPEAT_MON | ALARM_REPEAT_TUE |
+                             ALARM_REPEAT_WED | ALARM_REPEAT_THU | ALARM_REPEAT_FRI),
+    ALARM_REPEAT_WEEKEND  = (ALARM_REPEAT_SAT | ALARM_REPEAT_SUN),
+    ALARM_REPEAT_EVERYDAY = 0x7F,
+    ALARM_REPEAT_ONCE     = 0x00,  /**< One-time alarm (no repeat) */
+} alarm_repeat_day_t;
+
+/**
+ * @brief Alarm entry structure
+ */
+typedef struct {
+    uint8_t  hour;                            /**< Hour (0-23) */
+    uint8_t  minute;                          /**< Minute (0-59) */
+    uint8_t  repeat_days;                     /**< Bitmask of alarm_repeat_day_t */
+    bool     enabled;                         /**< Alarm enabled flag */
+    char     sound_path[ALARM_SOUND_PATH_LEN]; /**< Sound file path (empty = default) */
+} alarm_entry_t;
+
+/**
+ * @brief Alarm event types
+ */
+typedef enum {
+    ALARM_EVENT_TRIGGERED,   /**< Alarm triggered - sound starting */
+    ALARM_EVENT_DISMISSED,   /**< Alarm dismissed by user */
+    ALARM_EVENT_SNOOZED,     /**< Alarm snoozed */
+    ALARM_EVENT_EXPIRED,     /**< Alarm expired (auto-dismiss after timeout) */
+} alarm_event_t;
+
+/**
+ * @brief Alarm event callback
+ *
+ * @param event Event type
+ * @param index Alarm index that triggered the event
+ * @param user_data User-provided context
+ */
+typedef void (*alarm_event_cb_t)(alarm_event_t event, uint8_t index, void *user_data);
+
+/**
+ * @brief Initialize alarm system
+ *
+ * Loads alarms from NVS and starts time checking task.
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t alarm_init(void);
+
+/**
+ * @brief Deinitialize alarm system
+ */
+void alarm_deinit(void);
+
+/**
+ * @brief Get alarm entry
+ *
+ * @param index Alarm index (0 to ALARM_MAX_COUNT-1)
+ * @param alarm Output alarm entry
+ * @return ESP_OK on success, ESP_ERR_INVALID_ARG if index out of range
+ */
+esp_err_t alarm_get(uint8_t index, alarm_entry_t *alarm);
+
+/**
+ * @brief Set alarm entry
+ *
+ * Saves to NVS immediately.
+ *
+ * @param index Alarm index (0 to ALARM_MAX_COUNT-1)
+ * @param alarm Alarm entry to set
+ * @return ESP_OK on success
+ */
+esp_err_t alarm_set(uint8_t index, const alarm_entry_t *alarm);
+
+/**
+ * @brief Delete (disable and clear) alarm entry
+ *
+ * @param index Alarm index (0 to ALARM_MAX_COUNT-1)
+ * @return ESP_OK on success
+ */
+esp_err_t alarm_delete(uint8_t index);
+
+/**
+ * @brief Get count of enabled alarms
+ *
+ * @return Number of enabled alarms
+ */
+uint8_t alarm_get_enabled_count(void);
+
+/**
+ * @brief Check if any alarm is currently triggered
+ *
+ * @return true if alarm is playing
+ */
+bool alarm_is_triggered(void);
+
+/**
+ * @brief Get index of currently triggered alarm
+ *
+ * @return Triggered alarm index, or 0xFF if none
+ */
+uint8_t alarm_get_triggered_index(void);
+
+/**
+ * @brief Dismiss currently triggered alarm
+ *
+ * Stops alarm sound and clears triggered state.
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t alarm_dismiss(void);
+
+/**
+ * @brief Snooze currently triggered alarm
+ *
+ * Stops alarm sound and schedules re-trigger after ALARM_SNOOZE_MINUTES.
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t alarm_snooze(void);
+
+/**
+ * @brief Check time and trigger alarms if needed
+ *
+ * Call this periodically (e.g., every second from RTC update task).
+ *
+ * @param now Current time
+ */
+void alarm_check_time(const struct tm *now);
+
+/**
+ * @brief Register alarm event callback
+ *
+ * @param callback Callback function (NULL to unregister)
+ * @param user_data User context passed to callback
+ * @return ESP_OK on success
+ */
+esp_err_t alarm_register_callback(alarm_event_cb_t callback, void *user_data);
+
+/**
+ * @brief Get all alarms (for UI display)
+ *
+ * @param alarms Array of ALARM_MAX_COUNT entries
+ * @return ESP_OK on success
+ */
+esp_err_t alarm_get_all(alarm_entry_t alarms[ALARM_MAX_COUNT]);
+
+#ifdef __cplusplus
+}
+#endif

--- a/03.firmware/04.integratedAPP/components/alarm/src/alarm.c
+++ b/03.firmware/04.integratedAPP/components/alarm/src/alarm.c
@@ -1,0 +1,500 @@
+/**
+ * @file alarm.c
+ * @brief Alarm Management Implementation
+ */
+
+#include "alarm.h"
+#include "audio_player.h"
+#include "esp_log.h"
+#include "nvs_flash.h"
+#include "nvs.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+#include <string.h>
+#include <sys/stat.h>
+
+static const char *TAG = "ALARM";
+
+// NVS configuration
+#define NVS_NAMESPACE    "alarm_cfg"
+#define NVS_KEY_PREFIX   "alarm_"
+
+// Alarm volume
+#define ALARM_VOLUME     85
+
+// Auto-dismiss timeout (minutes)
+#define ALARM_AUTO_DISMISS_MINUTES 5
+
+// Alarm state
+static struct {
+    alarm_entry_t alarms[ALARM_MAX_COUNT];
+    nvs_handle_t nvs_handle;
+    bool nvs_opened;
+    bool initialized;
+
+    // Triggered state
+    bool triggered;
+    uint8_t triggered_index;
+    time_t triggered_time;
+
+    // Snooze state
+    bool snooze_active;
+    uint8_t snooze_index;
+    time_t snooze_until;
+
+    // Callback
+    alarm_event_cb_t callback;
+    void *callback_user_data;
+
+    // Thread safety
+    SemaphoreHandle_t mutex;
+
+    // Last checked minute (to avoid duplicate triggers)
+    int last_checked_minute;
+    int last_checked_hour;
+} s_alarm = {
+    .triggered_index = 0xFF,
+    .snooze_index = 0xFF,
+    .last_checked_minute = -1,
+    .last_checked_hour = -1,
+};
+
+/**
+ * @brief Generate NVS key for alarm index
+ */
+static void get_nvs_key(uint8_t index, char *key, size_t key_len)
+{
+    snprintf(key, key_len, "%s%d", NVS_KEY_PREFIX, index);
+}
+
+/**
+ * @brief Load single alarm from NVS
+ */
+static esp_err_t load_alarm(uint8_t index)
+{
+    if (!s_alarm.nvs_opened) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    char key[16];
+    get_nvs_key(index, key, sizeof(key));
+
+    size_t size = sizeof(alarm_entry_t);
+    esp_err_t ret = nvs_get_blob(s_alarm.nvs_handle, key, &s_alarm.alarms[index], &size);
+
+    if (ret == ESP_ERR_NVS_NOT_FOUND) {
+        // Initialize with defaults
+        memset(&s_alarm.alarms[index], 0, sizeof(alarm_entry_t));
+        s_alarm.alarms[index].hour = 7;
+        s_alarm.alarms[index].minute = 0;
+        s_alarm.alarms[index].enabled = false;
+        return ESP_OK;
+    }
+
+    return ret;
+}
+
+/**
+ * @brief Save single alarm to NVS
+ */
+static esp_err_t save_alarm(uint8_t index)
+{
+    if (!s_alarm.nvs_opened) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    char key[16];
+    get_nvs_key(index, key, sizeof(key));
+
+    esp_err_t ret = nvs_set_blob(s_alarm.nvs_handle, key, &s_alarm.alarms[index], sizeof(alarm_entry_t));
+    if (ret == ESP_OK) {
+        ret = nvs_commit(s_alarm.nvs_handle);
+    }
+
+    return ret;
+}
+
+/**
+ * @brief Check if sound file exists
+ */
+static bool sound_file_exists(const char *path)
+{
+    if (!path || path[0] == '\0') {
+        return false;
+    }
+
+    struct stat st;
+    return (stat(path, &st) == 0);
+}
+
+/**
+ * @brief Get sound path for alarm (use default if not set or not found)
+ */
+static const char* get_sound_path(uint8_t index)
+{
+    const char *path = s_alarm.alarms[index].sound_path;
+
+    if (path[0] != '\0' && sound_file_exists(path)) {
+        return path;
+    }
+
+    // Try default sound
+    if (sound_file_exists(ALARM_DEFAULT_SOUND)) {
+        return ALARM_DEFAULT_SOUND;
+    }
+
+    return NULL;
+}
+
+/**
+ * @brief Trigger alarm playback
+ */
+static void trigger_alarm(uint8_t index)
+{
+    const char *sound_path = get_sound_path(index);
+
+    ESP_LOGI(TAG, "Alarm %d triggered at %02d:%02d",
+             index, s_alarm.alarms[index].hour, s_alarm.alarms[index].minute);
+
+    s_alarm.triggered = true;
+    s_alarm.triggered_index = index;
+    s_alarm.triggered_time = time(NULL);
+    s_alarm.snooze_active = false;
+
+    // Play sound
+    if (sound_path) {
+        esp_err_t ret = audio_player_play_file(sound_path, ALARM_VOLUME, true);
+        if (ret != ESP_OK) {
+            ESP_LOGW(TAG, "Failed to play alarm sound: %s", esp_err_to_name(ret));
+        }
+    } else {
+        ESP_LOGW(TAG, "No alarm sound file available");
+    }
+
+    // Invoke callback
+    if (s_alarm.callback) {
+        s_alarm.callback(ALARM_EVENT_TRIGGERED, index, s_alarm.callback_user_data);
+    }
+
+    // Disable one-time alarms
+    if (s_alarm.alarms[index].repeat_days == ALARM_REPEAT_ONCE) {
+        s_alarm.alarms[index].enabled = false;
+        save_alarm(index);
+    }
+}
+
+/**
+ * @brief Audio playback completion callback
+ */
+static void audio_callback(void *user_data, bool completed)
+{
+    (void)user_data;
+    // If playback completed (not stopped), alarm expired
+    if (completed && s_alarm.triggered) {
+        ESP_LOGI(TAG, "Alarm audio completed");
+    }
+}
+
+esp_err_t alarm_init(void)
+{
+    if (s_alarm.initialized) {
+        ESP_LOGW(TAG, "Alarm already initialized");
+        return ESP_OK;
+    }
+
+    ESP_LOGI(TAG, "Initializing alarm system...");
+
+    // Create mutex
+    s_alarm.mutex = xSemaphoreCreateMutex();
+    if (!s_alarm.mutex) {
+        ESP_LOGE(TAG, "Failed to create mutex");
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Open NVS namespace
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &s_alarm.nvs_handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to open NVS namespace: %s", esp_err_to_name(ret));
+        vSemaphoreDelete(s_alarm.mutex);
+        return ret;
+    }
+    s_alarm.nvs_opened = true;
+
+    // Load all alarms
+    for (uint8_t i = 0; i < ALARM_MAX_COUNT; i++) {
+        load_alarm(i);
+        if (s_alarm.alarms[i].enabled) {
+            ESP_LOGI(TAG, "Alarm %d: %02d:%02d (repeat=0x%02X)",
+                     i, s_alarm.alarms[i].hour, s_alarm.alarms[i].minute,
+                     s_alarm.alarms[i].repeat_days);
+        }
+    }
+
+    // Initialize audio player if not already
+    ret = audio_player_init();
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+        ESP_LOGW(TAG, "Audio player init: %s", esp_err_to_name(ret));
+    }
+
+    // Register audio callback
+    audio_player_register_callback(audio_callback, NULL);
+
+    s_alarm.initialized = true;
+    ESP_LOGI(TAG, "Alarm system initialized (%d alarms enabled)", alarm_get_enabled_count());
+
+    return ESP_OK;
+}
+
+void alarm_deinit(void)
+{
+    if (!s_alarm.initialized) {
+        return;
+    }
+
+    ESP_LOGI(TAG, "Deinitializing alarm system...");
+
+    // Stop any playing alarm
+    if (s_alarm.triggered) {
+        audio_player_stop();
+    }
+
+    // Close NVS
+    if (s_alarm.nvs_opened) {
+        nvs_close(s_alarm.nvs_handle);
+        s_alarm.nvs_opened = false;
+    }
+
+    if (s_alarm.mutex) {
+        vSemaphoreDelete(s_alarm.mutex);
+        s_alarm.mutex = NULL;
+    }
+
+    s_alarm.initialized = false;
+    ESP_LOGI(TAG, "Alarm system deinitialized");
+}
+
+esp_err_t alarm_get(uint8_t index, alarm_entry_t *alarm)
+{
+    if (index >= ALARM_MAX_COUNT || !alarm) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (xSemaphoreTake(s_alarm.mutex, pdMS_TO_TICKS(100)) != pdTRUE) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    memcpy(alarm, &s_alarm.alarms[index], sizeof(alarm_entry_t));
+
+    xSemaphoreGive(s_alarm.mutex);
+    return ESP_OK;
+}
+
+esp_err_t alarm_set(uint8_t index, const alarm_entry_t *alarm)
+{
+    if (index >= ALARM_MAX_COUNT || !alarm) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (alarm->hour > 23 || alarm->minute > 59) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (xSemaphoreTake(s_alarm.mutex, pdMS_TO_TICKS(100)) != pdTRUE) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    memcpy(&s_alarm.alarms[index], alarm, sizeof(alarm_entry_t));
+    esp_err_t ret = save_alarm(index);
+
+    ESP_LOGI(TAG, "Alarm %d set: %02d:%02d, repeat=0x%02X, enabled=%d",
+             index, alarm->hour, alarm->minute, alarm->repeat_days, alarm->enabled);
+
+    xSemaphoreGive(s_alarm.mutex);
+    return ret;
+}
+
+esp_err_t alarm_delete(uint8_t index)
+{
+    if (index >= ALARM_MAX_COUNT) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (xSemaphoreTake(s_alarm.mutex, pdMS_TO_TICKS(100)) != pdTRUE) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    memset(&s_alarm.alarms[index], 0, sizeof(alarm_entry_t));
+    s_alarm.alarms[index].hour = 7;
+    s_alarm.alarms[index].enabled = false;
+
+    esp_err_t ret = save_alarm(index);
+
+    ESP_LOGI(TAG, "Alarm %d deleted", index);
+
+    xSemaphoreGive(s_alarm.mutex);
+    return ret;
+}
+
+uint8_t alarm_get_enabled_count(void)
+{
+    uint8_t count = 0;
+    for (uint8_t i = 0; i < ALARM_MAX_COUNT; i++) {
+        if (s_alarm.alarms[i].enabled) {
+            count++;
+        }
+    }
+    return count;
+}
+
+bool alarm_is_triggered(void)
+{
+    return s_alarm.triggered;
+}
+
+uint8_t alarm_get_triggered_index(void)
+{
+    return s_alarm.triggered_index;
+}
+
+esp_err_t alarm_dismiss(void)
+{
+    if (!s_alarm.triggered) {
+        return ESP_OK;
+    }
+
+    ESP_LOGI(TAG, "Alarm %d dismissed", s_alarm.triggered_index);
+
+    audio_player_stop();
+
+    uint8_t index = s_alarm.triggered_index;
+    s_alarm.triggered = false;
+    s_alarm.triggered_index = 0xFF;
+    s_alarm.snooze_active = false;
+
+    if (s_alarm.callback) {
+        s_alarm.callback(ALARM_EVENT_DISMISSED, index, s_alarm.callback_user_data);
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t alarm_snooze(void)
+{
+    if (!s_alarm.triggered) {
+        return ESP_OK;
+    }
+
+    ESP_LOGI(TAG, "Alarm %d snoozed for %d minutes",
+             s_alarm.triggered_index, ALARM_SNOOZE_MINUTES);
+
+    audio_player_stop();
+
+    uint8_t index = s_alarm.triggered_index;
+    s_alarm.triggered = false;
+    s_alarm.triggered_index = 0xFF;
+
+    // Set snooze
+    s_alarm.snooze_active = true;
+    s_alarm.snooze_index = index;
+    s_alarm.snooze_until = time(NULL) + (ALARM_SNOOZE_MINUTES * 60);
+
+    if (s_alarm.callback) {
+        s_alarm.callback(ALARM_EVENT_SNOOZED, index, s_alarm.callback_user_data);
+    }
+
+    return ESP_OK;
+}
+
+void alarm_check_time(const struct tm *now)
+{
+    if (!s_alarm.initialized || !now) {
+        return;
+    }
+
+    // Only check once per minute
+    if (now->tm_hour == s_alarm.last_checked_hour &&
+        now->tm_min == s_alarm.last_checked_minute) {
+        // Still check for snooze and auto-dismiss
+        goto check_snooze;
+    }
+
+    s_alarm.last_checked_hour = now->tm_hour;
+    s_alarm.last_checked_minute = now->tm_min;
+
+    // Don't check if alarm already triggered
+    if (s_alarm.triggered) {
+        // Check for auto-dismiss
+        time_t elapsed = time(NULL) - s_alarm.triggered_time;
+        if (elapsed > (ALARM_AUTO_DISMISS_MINUTES * 60)) {
+            ESP_LOGI(TAG, "Alarm %d auto-dismissed after timeout", s_alarm.triggered_index);
+            uint8_t index = s_alarm.triggered_index;
+            audio_player_stop();
+            s_alarm.triggered = false;
+            s_alarm.triggered_index = 0xFF;
+
+            if (s_alarm.callback) {
+                s_alarm.callback(ALARM_EVENT_EXPIRED, index, s_alarm.callback_user_data);
+            }
+        }
+        return;
+    }
+
+    // Check each enabled alarm
+    uint8_t wday_mask = (1 << now->tm_wday);  // tm_wday: 0=Sunday
+
+    for (uint8_t i = 0; i < ALARM_MAX_COUNT; i++) {
+        if (!s_alarm.alarms[i].enabled) {
+            continue;
+        }
+
+        // Check time match
+        if (s_alarm.alarms[i].hour != now->tm_hour ||
+            s_alarm.alarms[i].minute != now->tm_min) {
+            continue;
+        }
+
+        // Check day match (0 = one-time, always triggers)
+        if (s_alarm.alarms[i].repeat_days != ALARM_REPEAT_ONCE &&
+            !(s_alarm.alarms[i].repeat_days & wday_mask)) {
+            continue;
+        }
+
+        // Trigger alarm
+        trigger_alarm(i);
+        return;  // Only trigger one alarm at a time
+    }
+
+check_snooze:
+    // Check snooze
+    if (s_alarm.snooze_active && !s_alarm.triggered) {
+        if (time(NULL) >= s_alarm.snooze_until) {
+            ESP_LOGI(TAG, "Snooze alarm %d re-triggering", s_alarm.snooze_index);
+            s_alarm.snooze_active = false;
+            trigger_alarm(s_alarm.snooze_index);
+        }
+    }
+}
+
+esp_err_t alarm_register_callback(alarm_event_cb_t callback, void *user_data)
+{
+    s_alarm.callback = callback;
+    s_alarm.callback_user_data = user_data;
+    return ESP_OK;
+}
+
+esp_err_t alarm_get_all(alarm_entry_t alarms[ALARM_MAX_COUNT])
+{
+    if (!alarms) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (xSemaphoreTake(s_alarm.mutex, pdMS_TO_TICKS(100)) != pdTRUE) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    memcpy(alarms, s_alarm.alarms, sizeof(alarm_entry_t) * ALARM_MAX_COUNT);
+
+    xSemaphoreGive(s_alarm.mutex);
+    return ESP_OK;
+}

--- a/03.firmware/04.integratedAPP/components/audio_player/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/components/audio_player/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Audio Player component
+# WAV file playback via ES8311 codec
+
+idf_component_register(
+    SRCS
+        "src/audio_player.c"
+    INCLUDE_DIRS
+        "include"
+    REQUIRES
+        freertos
+        esp_common
+        log
+    PRIV_REQUIRES
+        bsp_jc4880p443c
+)

--- a/03.firmware/04.integratedAPP/components/audio_player/include/audio_player.h
+++ b/03.firmware/04.integratedAPP/components/audio_player/include/audio_player.h
@@ -1,0 +1,130 @@
+/**
+ * @file audio_player.h
+ * @brief Audio Player API - WAV file playback via ES8311 codec
+ *
+ * Provides background audio playback from SD card WAV files.
+ * Uses FreeRTOS task for non-blocking playback.
+ */
+
+#pragma once
+
+#include "esp_err.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Audio player state
+ */
+typedef enum {
+    AUDIO_PLAYER_STATE_IDLE,      /**< Not playing */
+    AUDIO_PLAYER_STATE_PLAYING,   /**< Currently playing */
+    AUDIO_PLAYER_STATE_PAUSED,    /**< Playback paused */
+    AUDIO_PLAYER_STATE_ERROR      /**< Error occurred */
+} audio_player_state_t;
+
+/**
+ * @brief Playback completion callback
+ *
+ * @param user_data User-provided context
+ * @param completed true if playback finished normally, false if stopped
+ */
+typedef void (*audio_player_callback_t)(void *user_data, bool completed);
+
+/**
+ * @brief Initialize the audio player
+ *
+ * Initializes the ES8311 codec via BSP and prepares for playback.
+ * Must be called before other audio_player functions.
+ *
+ * @return ESP_OK on success, error code otherwise
+ */
+esp_err_t audio_player_init(void);
+
+/**
+ * @brief Deinitialize the audio player
+ *
+ * Stops any active playback and releases resources.
+ */
+void audio_player_deinit(void);
+
+/**
+ * @brief Play a WAV file from SD card
+ *
+ * Starts background playback of the specified WAV file.
+ * Supports PCM WAV files (8/16-bit, mono/stereo, 8000-48000Hz).
+ *
+ * @param file_path Full path to WAV file (e.g., "/sdcard/sounds/alarm.wav")
+ * @param volume Volume level (0-100)
+ * @param loop If true, loops playback until stopped
+ * @return ESP_OK on success, error code otherwise
+ */
+esp_err_t audio_player_play_file(const char *file_path, uint8_t volume, bool loop);
+
+/**
+ * @brief Stop current playback
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t audio_player_stop(void);
+
+/**
+ * @brief Pause current playback
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t audio_player_pause(void);
+
+/**
+ * @brief Resume paused playback
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t audio_player_resume(void);
+
+/**
+ * @brief Set playback volume
+ *
+ * @param volume Volume level (0-100)
+ * @return ESP_OK on success
+ */
+esp_err_t audio_player_set_volume(uint8_t volume);
+
+/**
+ * @brief Get current volume level
+ *
+ * @return Current volume (0-100)
+ */
+uint8_t audio_player_get_volume(void);
+
+/**
+ * @brief Check if audio is currently playing
+ *
+ * @return true if playing, false otherwise
+ */
+bool audio_player_is_playing(void);
+
+/**
+ * @brief Get current player state
+ *
+ * @return Current state
+ */
+audio_player_state_t audio_player_get_state(void);
+
+/**
+ * @brief Register playback completion callback
+ *
+ * Callback is invoked when playback completes or is stopped.
+ *
+ * @param callback Callback function (NULL to unregister)
+ * @param user_data User context passed to callback
+ * @return ESP_OK on success
+ */
+esp_err_t audio_player_register_callback(audio_player_callback_t callback, void *user_data);
+
+#ifdef __cplusplus
+}
+#endif

--- a/03.firmware/04.integratedAPP/components/audio_player/src/audio_player.c
+++ b/03.firmware/04.integratedAPP/components/audio_player/src/audio_player.c
@@ -1,0 +1,564 @@
+/**
+ * @file audio_player.c
+ * @brief Audio Player Implementation - WAV file playback via ES8311 codec
+ */
+
+#include "audio_player.h"
+#include "bsp/jc4880p443c.h"
+#include "esp_log.h"
+#include "esp_heap_caps.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/semphr.h"
+#include <stdio.h>
+#include <string.h>
+
+static const char *TAG = "AUDIO_PLAYER";
+
+// Task configuration
+#define AUDIO_TASK_STACK_SIZE  8192
+#define AUDIO_TASK_PRIORITY    6
+#define AUDIO_BUFFER_SIZE      4096  // PCM buffer size per read
+
+// WAV file header structures
+#pragma pack(push, 1)
+typedef struct {
+    char     riff_tag[4];      // "RIFF"
+    uint32_t file_size;        // File size - 8
+    char     wave_tag[4];      // "WAVE"
+} wav_riff_header_t;
+
+typedef struct {
+    char     chunk_id[4];      // "fmt " or "data"
+    uint32_t chunk_size;       // Chunk size
+} wav_chunk_header_t;
+
+typedef struct {
+    uint16_t audio_format;     // 1 = PCM
+    uint16_t num_channels;     // 1 = mono, 2 = stereo
+    uint32_t sample_rate;      // 8000, 16000, 22050, 44100, 48000
+    uint32_t byte_rate;        // sample_rate * num_channels * bits_per_sample/8
+    uint16_t block_align;      // num_channels * bits_per_sample/8
+    uint16_t bits_per_sample;  // 8 or 16
+} wav_fmt_chunk_t;
+#pragma pack(pop)
+
+// Player state
+static struct {
+    // Codec handle
+    esp_codec_dev_handle_t codec;
+    bool codec_initialized;
+    bool codec_opened;
+
+    // Playback state
+    audio_player_state_t state;
+    uint8_t volume;
+
+    // Current file info
+    FILE *file;
+    char file_path[128];
+    bool loop;
+    uint32_t data_offset;      // Start of PCM data in file
+    uint32_t data_size;        // Size of PCM data
+    uint32_t bytes_played;     // Bytes played so far
+
+    // Audio format
+    uint16_t sample_rate;
+    uint8_t  channels;
+    uint8_t  bits_per_sample;
+
+    // Task management
+    TaskHandle_t task_handle;
+    SemaphoreHandle_t mutex;
+    volatile bool task_running;
+    volatile bool stop_requested;
+
+    // Callback
+    audio_player_callback_t callback;
+    void *callback_user_data;
+
+    // PCM buffer (DMA capable)
+    uint8_t *pcm_buffer;
+} s_player = {
+    .state = AUDIO_PLAYER_STATE_IDLE,
+    .volume = 80,
+};
+
+/**
+ * @brief Parse WAV file header and find PCM data
+ */
+static esp_err_t parse_wav_header(FILE *file)
+{
+    wav_riff_header_t riff;
+    wav_chunk_header_t chunk;
+    wav_fmt_chunk_t fmt;
+    bool fmt_found = false;
+    bool data_found = false;
+
+    // Read RIFF header
+    if (fread(&riff, sizeof(riff), 1, file) != 1) {
+        ESP_LOGE(TAG, "Failed to read RIFF header");
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    // Validate RIFF/WAVE
+    if (memcmp(riff.riff_tag, "RIFF", 4) != 0 ||
+        memcmp(riff.wave_tag, "WAVE", 4) != 0) {
+        ESP_LOGE(TAG, "Not a valid WAV file");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    // Parse chunks
+    while (!data_found && fread(&chunk, sizeof(chunk), 1, file) == 1) {
+        if (memcmp(chunk.chunk_id, "fmt ", 4) == 0) {
+            // Format chunk
+            if (chunk.chunk_size < sizeof(fmt)) {
+                ESP_LOGE(TAG, "Invalid fmt chunk size");
+                return ESP_ERR_INVALID_SIZE;
+            }
+
+            if (fread(&fmt, sizeof(fmt), 1, file) != 1) {
+                ESP_LOGE(TAG, "Failed to read fmt chunk");
+                return ESP_ERR_INVALID_SIZE;
+            }
+
+            // Skip extra fmt data if any
+            if (chunk.chunk_size > sizeof(fmt)) {
+                fseek(file, chunk.chunk_size - sizeof(fmt), SEEK_CUR);
+            }
+
+            // Validate format
+            if (fmt.audio_format != 1) {
+                ESP_LOGE(TAG, "Unsupported audio format: %d (only PCM supported)", fmt.audio_format);
+                return ESP_ERR_NOT_SUPPORTED;
+            }
+
+            if (fmt.bits_per_sample != 8 && fmt.bits_per_sample != 16) {
+                ESP_LOGE(TAG, "Unsupported bits per sample: %d", fmt.bits_per_sample);
+                return ESP_ERR_NOT_SUPPORTED;
+            }
+
+            if (fmt.num_channels != 1 && fmt.num_channels != 2) {
+                ESP_LOGE(TAG, "Unsupported channels: %d", fmt.num_channels);
+                return ESP_ERR_NOT_SUPPORTED;
+            }
+
+            s_player.sample_rate = fmt.sample_rate;
+            s_player.channels = fmt.num_channels;
+            s_player.bits_per_sample = fmt.bits_per_sample;
+            fmt_found = true;
+
+            ESP_LOGI(TAG, "WAV format: %luHz, %d-bit, %s",
+                     (unsigned long)fmt.sample_rate,
+                     fmt.bits_per_sample,
+                     fmt.num_channels == 1 ? "mono" : "stereo");
+
+        } else if (memcmp(chunk.chunk_id, "data", 4) == 0) {
+            // Data chunk
+            if (!fmt_found) {
+                ESP_LOGE(TAG, "Data chunk before fmt chunk");
+                return ESP_ERR_INVALID_STATE;
+            }
+
+            s_player.data_offset = ftell(file);
+            s_player.data_size = chunk.chunk_size;
+            data_found = true;
+
+            ESP_LOGI(TAG, "WAV data: %lu bytes at offset %lu",
+                     (unsigned long)s_player.data_size,
+                     (unsigned long)s_player.data_offset);
+
+        } else {
+            // Skip unknown chunk
+            fseek(file, chunk.chunk_size, SEEK_CUR);
+        }
+    }
+
+    if (!fmt_found || !data_found) {
+        ESP_LOGE(TAG, "WAV file missing required chunks");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    return ESP_OK;
+}
+
+/**
+ * @brief Configure codec for current audio format
+ */
+static esp_err_t configure_codec(void)
+{
+    if (!s_player.codec) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    // Close previous session if open
+    if (s_player.codec_opened) {
+        esp_codec_dev_close(s_player.codec);
+        s_player.codec_opened = false;
+    }
+
+    // Configure sample info
+    esp_codec_dev_sample_info_t sample_info = {
+        .sample_rate = s_player.sample_rate,
+        .channel = s_player.channels,
+        .bits_per_sample = s_player.bits_per_sample,
+    };
+
+    esp_err_t ret = esp_codec_dev_open(s_player.codec, &sample_info);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to open codec: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    s_player.codec_opened = true;
+
+    // Set volume
+    ret = esp_codec_dev_set_out_vol(s_player.codec, s_player.volume);
+    if (ret != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to set volume: %s", esp_err_to_name(ret));
+    }
+
+    return ESP_OK;
+}
+
+/**
+ * @brief Audio playback task
+ */
+static void audio_playback_task(void *pvParameters)
+{
+    ESP_LOGI(TAG, "Playback task started");
+
+    while (s_player.task_running) {
+        if (s_player.state == AUDIO_PLAYER_STATE_PLAYING && s_player.file) {
+            // Read PCM data
+            size_t bytes_to_read = AUDIO_BUFFER_SIZE;
+            uint32_t remaining = s_player.data_size - s_player.bytes_played;
+
+            if (remaining < bytes_to_read) {
+                bytes_to_read = remaining;
+            }
+
+            if (bytes_to_read > 0) {
+                size_t bytes_read = fread(s_player.pcm_buffer, 1, bytes_to_read, s_player.file);
+
+                if (bytes_read > 0) {
+                    // Write to codec
+                    esp_err_t ret = esp_codec_dev_write(s_player.codec, s_player.pcm_buffer, bytes_read);
+                    if (ret != ESP_OK) {
+                        ESP_LOGE(TAG, "Codec write failed: %s", esp_err_to_name(ret));
+                        s_player.state = AUDIO_PLAYER_STATE_ERROR;
+                        continue;
+                    }
+                    s_player.bytes_played += bytes_read;
+                }
+            }
+
+            // Check for end of file
+            if (s_player.bytes_played >= s_player.data_size) {
+                if (s_player.loop && !s_player.stop_requested) {
+                    // Loop: seek back to start of data
+                    fseek(s_player.file, s_player.data_offset, SEEK_SET);
+                    s_player.bytes_played = 0;
+                    ESP_LOGD(TAG, "Looping playback");
+                } else {
+                    // Playback complete
+                    ESP_LOGI(TAG, "Playback complete");
+                    s_player.state = AUDIO_PLAYER_STATE_IDLE;
+
+                    // Close file
+                    if (s_player.file) {
+                        fclose(s_player.file);
+                        s_player.file = NULL;
+                    }
+
+                    // Invoke callback
+                    if (s_player.callback) {
+                        s_player.callback(s_player.callback_user_data, true);
+                    }
+                }
+            }
+
+            // Check for stop request
+            if (s_player.stop_requested) {
+                ESP_LOGI(TAG, "Stop requested");
+                s_player.state = AUDIO_PLAYER_STATE_IDLE;
+                s_player.stop_requested = false;
+
+                if (s_player.file) {
+                    fclose(s_player.file);
+                    s_player.file = NULL;
+                }
+
+                if (s_player.callback) {
+                    s_player.callback(s_player.callback_user_data, false);
+                }
+            }
+        } else if (s_player.state == AUDIO_PLAYER_STATE_PAUSED) {
+            // Paused - just wait
+            vTaskDelay(pdMS_TO_TICKS(50));
+        } else {
+            // Idle - wait for new playback
+            vTaskDelay(pdMS_TO_TICKS(100));
+        }
+    }
+
+    ESP_LOGI(TAG, "Playback task stopped");
+    vTaskDelete(NULL);
+}
+
+esp_err_t audio_player_init(void)
+{
+    if (s_player.codec_initialized) {
+        ESP_LOGW(TAG, "Audio player already initialized");
+        return ESP_OK;
+    }
+
+    ESP_LOGI(TAG, "Initializing audio player...");
+
+    // Create mutex
+    s_player.mutex = xSemaphoreCreateMutex();
+    if (!s_player.mutex) {
+        ESP_LOGE(TAG, "Failed to create mutex");
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Allocate PCM buffer (prefer PSRAM)
+    s_player.pcm_buffer = heap_caps_malloc(AUDIO_BUFFER_SIZE, MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT);
+    if (!s_player.pcm_buffer) {
+        s_player.pcm_buffer = heap_caps_malloc(AUDIO_BUFFER_SIZE, MALLOC_CAP_DEFAULT);
+    }
+    if (!s_player.pcm_buffer) {
+        ESP_LOGE(TAG, "Failed to allocate PCM buffer");
+        vSemaphoreDelete(s_player.mutex);
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Initialize codec via BSP
+    s_player.codec = bsp_audio_codec_speaker_init();
+    if (!s_player.codec) {
+        ESP_LOGE(TAG, "Failed to initialize audio codec");
+        free(s_player.pcm_buffer);
+        vSemaphoreDelete(s_player.mutex);
+        return ESP_FAIL;
+    }
+
+    s_player.codec_initialized = true;
+    s_player.state = AUDIO_PLAYER_STATE_IDLE;
+
+    // Create playback task
+    s_player.task_running = true;
+    BaseType_t ret = xTaskCreate(
+        audio_playback_task,
+        "audio_play",
+        AUDIO_TASK_STACK_SIZE,
+        NULL,
+        AUDIO_TASK_PRIORITY,
+        &s_player.task_handle
+    );
+
+    if (ret != pdPASS) {
+        ESP_LOGE(TAG, "Failed to create playback task");
+        s_player.task_running = false;
+        free(s_player.pcm_buffer);
+        vSemaphoreDelete(s_player.mutex);
+        return ESP_ERR_NO_MEM;
+    }
+
+    ESP_LOGI(TAG, "Audio player initialized");
+    return ESP_OK;
+}
+
+void audio_player_deinit(void)
+{
+    if (!s_player.codec_initialized) {
+        return;
+    }
+
+    ESP_LOGI(TAG, "Deinitializing audio player...");
+
+    // Stop task
+    s_player.task_running = false;
+    s_player.stop_requested = true;
+    vTaskDelay(pdMS_TO_TICKS(200));
+
+    // Close file if open
+    if (s_player.file) {
+        fclose(s_player.file);
+        s_player.file = NULL;
+    }
+
+    // Close codec
+    if (s_player.codec_opened) {
+        esp_codec_dev_close(s_player.codec);
+        s_player.codec_opened = false;
+    }
+
+    // Free resources
+    if (s_player.pcm_buffer) {
+        free(s_player.pcm_buffer);
+        s_player.pcm_buffer = NULL;
+    }
+
+    if (s_player.mutex) {
+        vSemaphoreDelete(s_player.mutex);
+        s_player.mutex = NULL;
+    }
+
+    s_player.codec_initialized = false;
+    s_player.state = AUDIO_PLAYER_STATE_IDLE;
+
+    ESP_LOGI(TAG, "Audio player deinitialized");
+}
+
+esp_err_t audio_player_play_file(const char *file_path, uint8_t volume, bool loop)
+{
+    if (!s_player.codec_initialized) {
+        ESP_LOGE(TAG, "Audio player not initialized");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (!file_path || strlen(file_path) == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (xSemaphoreTake(s_player.mutex, pdMS_TO_TICKS(1000)) != pdTRUE) {
+        return ESP_ERR_TIMEOUT;
+    }
+
+    // Stop any current playback
+    if (s_player.state == AUDIO_PLAYER_STATE_PLAYING) {
+        s_player.stop_requested = true;
+        xSemaphoreGive(s_player.mutex);
+        vTaskDelay(pdMS_TO_TICKS(100));
+        if (xSemaphoreTake(s_player.mutex, pdMS_TO_TICKS(1000)) != pdTRUE) {
+            return ESP_ERR_TIMEOUT;
+        }
+    }
+
+    // Open file
+    s_player.file = fopen(file_path, "rb");
+    if (!s_player.file) {
+        ESP_LOGE(TAG, "Failed to open file: %s", file_path);
+        xSemaphoreGive(s_player.mutex);
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    // Parse WAV header
+    esp_err_t ret = parse_wav_header(s_player.file);
+    if (ret != ESP_OK) {
+        fclose(s_player.file);
+        s_player.file = NULL;
+        xSemaphoreGive(s_player.mutex);
+        return ret;
+    }
+
+    // Configure codec
+    ret = configure_codec();
+    if (ret != ESP_OK) {
+        fclose(s_player.file);
+        s_player.file = NULL;
+        xSemaphoreGive(s_player.mutex);
+        return ret;
+    }
+
+    // Set volume
+    s_player.volume = volume > 100 ? 100 : volume;
+    esp_codec_dev_set_out_vol(s_player.codec, s_player.volume);
+
+    // Store settings
+    strncpy(s_player.file_path, file_path, sizeof(s_player.file_path) - 1);
+    s_player.loop = loop;
+    s_player.bytes_played = 0;
+    s_player.stop_requested = false;
+
+    // Seek to data start
+    fseek(s_player.file, s_player.data_offset, SEEK_SET);
+
+    // Start playback
+    s_player.state = AUDIO_PLAYER_STATE_PLAYING;
+
+    ESP_LOGI(TAG, "Playing: %s (vol=%d, loop=%d)", file_path, volume, loop);
+
+    xSemaphoreGive(s_player.mutex);
+    return ESP_OK;
+}
+
+esp_err_t audio_player_stop(void)
+{
+    if (!s_player.codec_initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    s_player.stop_requested = true;
+
+    // Wait for task to process stop
+    for (int i = 0; i < 20 && s_player.state == AUDIO_PLAYER_STATE_PLAYING; i++) {
+        vTaskDelay(pdMS_TO_TICKS(50));
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t audio_player_pause(void)
+{
+    if (!s_player.codec_initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (s_player.state == AUDIO_PLAYER_STATE_PLAYING) {
+        s_player.state = AUDIO_PLAYER_STATE_PAUSED;
+        ESP_LOGI(TAG, "Playback paused");
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t audio_player_resume(void)
+{
+    if (!s_player.codec_initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (s_player.state == AUDIO_PLAYER_STATE_PAUSED) {
+        s_player.state = AUDIO_PLAYER_STATE_PLAYING;
+        ESP_LOGI(TAG, "Playback resumed");
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t audio_player_set_volume(uint8_t volume)
+{
+    if (!s_player.codec_initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    s_player.volume = volume > 100 ? 100 : volume;
+
+    if (s_player.codec_opened) {
+        return esp_codec_dev_set_out_vol(s_player.codec, s_player.volume);
+    }
+
+    return ESP_OK;
+}
+
+uint8_t audio_player_get_volume(void)
+{
+    return s_player.volume;
+}
+
+bool audio_player_is_playing(void)
+{
+    return s_player.state == AUDIO_PLAYER_STATE_PLAYING;
+}
+
+audio_player_state_t audio_player_get_state(void)
+{
+    return s_player.state;
+}
+
+esp_err_t audio_player_register_callback(audio_player_callback_t callback, void *user_data)
+{
+    s_player.callback = callback;
+    s_player.callback_user_data = user_data;
+    return ESP_OK;
+}

--- a/03.firmware/04.integratedAPP/components/ui/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/components/ui/CMakeLists.txt
@@ -9,6 +9,6 @@ file(GLOB_RECURSE UI_SOURCES
 idf_component_register(
     SRCS ${UI_SOURCES}
     INCLUDE_DIRS "." "screens" "fonts" "images" "components"
-    REQUIRES lvgl ble_hid sdcard esp_driver_jpeg mjpeg_player
+    REQUIRES lvgl ble_hid sdcard esp_driver_jpeg mjpeg_player alarm
     PRIV_REQUIRES bsp_jc4880p443c
 )

--- a/03.firmware/04.integratedAPP/components/ui/ui_alarm.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_alarm.c
@@ -242,11 +242,13 @@ static void show_edit_dialog(uint8_t index)
     lv_obj_t *title = lv_label_create(s_edit_modal);
     lv_label_set_text(title, index < ALARM_MAX_COUNT ? "Edit Alarm" : "New Alarm");
     lv_obj_set_style_text_font(title, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_color(title, lv_color_hex(0xFFFFFF), 0);
 
     // Time label
     lv_obj_t *time_label = lv_label_create(s_edit_modal);
     lv_label_set_text(time_label, "Time:");
     lv_obj_set_style_text_font(time_label, &lv_font_montserrat_18, 0);
+    lv_obj_set_style_text_color(time_label, lv_color_hex(0xFFFFFF), 0);
 
     // Time row with dropdowns
     lv_obj_t *time_row = lv_obj_create(s_edit_modal);
@@ -270,6 +272,7 @@ static void show_edit_dialog(uint8_t index)
     lv_obj_t *colon = lv_label_create(time_row);
     lv_label_set_text(colon, ":");
     lv_obj_set_style_text_font(colon, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_color(colon, lv_color_hex(0xFFFFFF), 0);
 
     // Minute dropdown
     s_minute_dropdown = lv_dropdown_create(time_row);
@@ -283,6 +286,7 @@ static void show_edit_dialog(uint8_t index)
     lv_obj_t *days_label = lv_label_create(s_edit_modal);
     lv_label_set_text(days_label, "Repeat Days:");
     lv_obj_set_style_text_font(days_label, &lv_font_montserrat_18, 0);
+    lv_obj_set_style_text_color(days_label, lv_color_hex(0xFFFFFF), 0);
 
     // Days container (2 rows)
     lv_obj_t *days_container = lv_obj_create(s_edit_modal);
@@ -337,6 +341,7 @@ static void show_edit_dialog(uint8_t index)
     lv_obj_t *sound_label = lv_label_create(s_edit_modal);
     lv_label_set_text(sound_label, "Sound:");
     lv_obj_set_style_text_font(sound_label, &lv_font_montserrat_18, 0);
+    lv_obj_set_style_text_color(sound_label, lv_color_hex(0xFFFFFF), 0);
 
     // Sound dropdown
     s_sound_dropdown = lv_dropdown_create(s_edit_modal);
@@ -370,6 +375,7 @@ static void show_edit_dialog(uint8_t index)
     lv_obj_t *enable_label = lv_label_create(enable_row);
     lv_label_set_text(enable_label, "Enabled");
     lv_obj_set_style_text_font(enable_label, &lv_font_montserrat_18, 0);
+    lv_obj_set_style_text_color(enable_label, lv_color_hex(0xFFFFFF), 0);
 
     s_enable_switch = lv_switch_create(enable_row);
     lv_obj_set_size(s_enable_switch, 60, 30);
@@ -500,7 +506,9 @@ void ui_alarm_update_list(void)
         lv_obj_t *time_label = lv_label_create(item);
         lv_label_set_text(time_label, time_str);
         lv_obj_set_style_text_font(time_label, &lv_font_montserrat_20, 0);
-        if (!alarms[i].enabled) {
+        if (alarms[i].enabled) {
+            lv_obj_set_style_text_color(time_label, lv_color_hex(0xFFFFFF), 0);
+        } else {
             lv_obj_set_style_text_color(time_label, lv_color_hex(0x888888), 0);
         }
 
@@ -590,11 +598,13 @@ void ui_alarm_show_trigger_popup(uint8_t alarm_index)
     snprintf(time_str, sizeof(time_str), "%02d:%02d", alarm.hour, alarm.minute);
     lv_label_set_text(s_trigger_time_label, time_str);
     lv_obj_set_style_text_font(s_trigger_time_label, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_color(s_trigger_time_label, lv_color_hex(0xFFFFFF), 0);
 
     // Alarm label
     lv_obj_t *label = lv_label_create(s_trigger_popup);
     lv_label_set_text(label, "ALARM");
     lv_obj_set_style_text_font(label, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_color(label, lv_color_hex(0xFF6B6B), 0);
 
     // Button container
     lv_obj_t *btn_container = lv_obj_create(s_trigger_popup);

--- a/03.firmware/04.integratedAPP/components/ui/ui_alarm.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_alarm.c
@@ -22,13 +22,27 @@ static lv_obj_t *s_add_btn = NULL;
 
 // Edit dialog elements
 static lv_obj_t *s_edit_modal = NULL;
-static lv_obj_t *s_hour_spinbox = NULL;
-static lv_obj_t *s_minute_spinbox = NULL;
+static lv_obj_t *s_hour_dropdown = NULL;
+static lv_obj_t *s_minute_dropdown = NULL;
 static lv_obj_t *s_day_checkboxes[7] = {NULL};
 static lv_obj_t *s_sound_dropdown = NULL;
 static lv_obj_t *s_enable_switch = NULL;
 static lv_obj_t *s_delete_btn = NULL;
 static uint8_t s_editing_index = 0xFF;
+
+// Hour options (0-23)
+static const char *HOUR_OPTIONS =
+    "00\n01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n11\n"
+    "12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23";
+
+// Minute options (0-59)
+static const char *MINUTE_OPTIONS =
+    "00\n01\n02\n03\n04\n05\n06\n07\n08\n09\n"
+    "10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n"
+    "20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n"
+    "30\n31\n32\n33\n34\n35\n36\n37\n38\n39\n"
+    "40\n41\n42\n43\n44\n45\n46\n47\n48\n49\n"
+    "50\n51\n52\n53\n54\n55\n56\n57\n58\n59";
 
 // Trigger popup elements
 static lv_obj_t *s_trigger_popup = NULL;
@@ -120,8 +134,8 @@ static void close_edit_dialog(void)
     if (s_edit_modal) {
         lv_obj_delete(s_edit_modal);
         s_edit_modal = NULL;
-        s_hour_spinbox = NULL;
-        s_minute_spinbox = NULL;
+        s_hour_dropdown = NULL;
+        s_minute_dropdown = NULL;
         for (int i = 0; i < 7; i++) {
             s_day_checkboxes[i] = NULL;
         }
@@ -140,9 +154,9 @@ static void save_alarm_cb(lv_event_t *e)
     alarm_entry_t alarm;
     memset(&alarm, 0, sizeof(alarm));
 
-    // Get time
-    alarm.hour = (uint8_t)lv_spinbox_get_value(s_hour_spinbox);
-    alarm.minute = (uint8_t)lv_spinbox_get_value(s_minute_spinbox);
+    // Get time from dropdowns
+    alarm.hour = (uint8_t)lv_dropdown_get_selected(s_hour_dropdown);
+    alarm.minute = (uint8_t)lv_dropdown_get_selected(s_minute_dropdown);
 
     // Get repeat days
     alarm.repeat_days = 0;
@@ -211,63 +225,68 @@ static void show_edit_dialog(uint8_t index)
         alarm.enabled = true;
     }
 
-    // Create modal background
+    // Create modal background (larger dialog for better visibility)
     s_edit_modal = lv_obj_create(lv_screen_active());
-    lv_obj_set_size(s_edit_modal, 280, 420);
+    lv_obj_set_size(s_edit_modal, 400, 600);
     lv_obj_center(s_edit_modal);
     lv_obj_set_style_bg_color(s_edit_modal, lv_color_hex(0x1E1E1E), 0);
     lv_obj_set_style_border_color(s_edit_modal, lv_color_hex(0x444444), 0);
     lv_obj_set_style_border_width(s_edit_modal, 2, 0);
     lv_obj_set_style_radius(s_edit_modal, 12, 0);
-    lv_obj_set_style_pad_all(s_edit_modal, 15, 0);
+    lv_obj_set_style_pad_all(s_edit_modal, 20, 0);
     lv_obj_set_flex_flow(s_edit_modal, LV_FLEX_FLOW_COLUMN);
     lv_obj_set_flex_align(s_edit_modal, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_pad_row(s_edit_modal, 10, 0);
+    lv_obj_set_style_pad_row(s_edit_modal, 15, 0);
 
     // Title
     lv_obj_t *title = lv_label_create(s_edit_modal);
     lv_label_set_text(title, index < ALARM_MAX_COUNT ? "Edit Alarm" : "New Alarm");
-    lv_obj_set_style_text_font(title, &lv_font_montserrat_18, 0);
+    lv_obj_set_style_text_font(title, &lv_font_montserrat_24, 0);
 
-    // Time row
+    // Time label
+    lv_obj_t *time_label = lv_label_create(s_edit_modal);
+    lv_label_set_text(time_label, "Time:");
+    lv_obj_set_style_text_font(time_label, &lv_font_montserrat_18, 0);
+
+    // Time row with dropdowns
     lv_obj_t *time_row = lv_obj_create(s_edit_modal);
-    lv_obj_set_size(time_row, 250, 60);
+    lv_obj_set_size(time_row, 360, 80);
     lv_obj_set_flex_flow(time_row, LV_FLEX_FLOW_ROW);
     lv_obj_set_flex_align(time_row, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
     lv_obj_set_style_bg_opa(time_row, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(time_row, 0, 0);
     lv_obj_set_style_pad_all(time_row, 5, 0);
-    lv_obj_set_style_pad_column(time_row, 10, 0);
+    lv_obj_set_style_pad_column(time_row, 15, 0);
 
-    // Hour spinbox
-    s_hour_spinbox = lv_spinbox_create(time_row);
-    lv_spinbox_set_range(s_hour_spinbox, 0, 23);
-    lv_spinbox_set_digit_format(s_hour_spinbox, 2, 0);
-    lv_spinbox_set_value(s_hour_spinbox, alarm.hour);
-    lv_obj_set_width(s_hour_spinbox, 70);
-    lv_obj_set_style_text_font(s_hour_spinbox, &lv_font_montserrat_24, 0);
+    // Hour dropdown
+    s_hour_dropdown = lv_dropdown_create(time_row);
+    lv_dropdown_set_options(s_hour_dropdown, HOUR_OPTIONS);
+    lv_dropdown_set_selected(s_hour_dropdown, alarm.hour);
+    lv_obj_set_width(s_hour_dropdown, 120);
+    lv_obj_set_style_text_font(s_hour_dropdown, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_font(s_hour_dropdown, &lv_font_montserrat_20, LV_PART_INDICATOR);
 
     // Colon
     lv_obj_t *colon = lv_label_create(time_row);
     lv_label_set_text(colon, ":");
     lv_obj_set_style_text_font(colon, &lv_font_montserrat_24, 0);
 
-    // Minute spinbox
-    s_minute_spinbox = lv_spinbox_create(time_row);
-    lv_spinbox_set_range(s_minute_spinbox, 0, 59);
-    lv_spinbox_set_digit_format(s_minute_spinbox, 2, 0);
-    lv_spinbox_set_value(s_minute_spinbox, alarm.minute);
-    lv_obj_set_width(s_minute_spinbox, 70);
-    lv_obj_set_style_text_font(s_minute_spinbox, &lv_font_montserrat_24, 0);
+    // Minute dropdown
+    s_minute_dropdown = lv_dropdown_create(time_row);
+    lv_dropdown_set_options(s_minute_dropdown, MINUTE_OPTIONS);
+    lv_dropdown_set_selected(s_minute_dropdown, alarm.minute);
+    lv_obj_set_width(s_minute_dropdown, 120);
+    lv_obj_set_style_text_font(s_minute_dropdown, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_font(s_minute_dropdown, &lv_font_montserrat_20, LV_PART_INDICATOR);
 
     // Days label
     lv_obj_t *days_label = lv_label_create(s_edit_modal);
-    lv_label_set_text(days_label, "Repeat:");
-    lv_obj_set_style_text_font(days_label, &lv_font_montserrat_14, 0);
+    lv_label_set_text(days_label, "Repeat Days:");
+    lv_obj_set_style_text_font(days_label, &lv_font_montserrat_18, 0);
 
     // Days row
     lv_obj_t *days_row = lv_obj_create(s_edit_modal);
-    lv_obj_set_size(days_row, 250, 35);
+    lv_obj_set_size(days_row, 360, 50);
     lv_obj_set_flex_flow(days_row, LV_FLEX_FLOW_ROW);
     lv_obj_set_flex_align(days_row, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
     lv_obj_set_style_bg_opa(days_row, LV_OPA_TRANSP, 0);
@@ -277,7 +296,8 @@ static void show_edit_dialog(uint8_t index)
     for (int i = 0; i < 7; i++) {
         s_day_checkboxes[i] = lv_checkbox_create(days_row);
         lv_checkbox_set_text(s_day_checkboxes[i], DAY_NAMES[i]);
-        lv_obj_set_style_text_font(s_day_checkboxes[i], &lv_font_montserrat_12, 0);
+        lv_obj_set_style_text_font(s_day_checkboxes[i], &lv_font_montserrat_14, 0);
+        lv_obj_set_style_text_color(s_day_checkboxes[i], lv_color_hex(0xFFFFFF), 0);
         if (alarm.repeat_days & (1 << i)) {
             lv_obj_add_state(s_day_checkboxes[i], LV_STATE_CHECKED);
         }
@@ -286,12 +306,12 @@ static void show_edit_dialog(uint8_t index)
     // Sound label
     lv_obj_t *sound_label = lv_label_create(s_edit_modal);
     lv_label_set_text(sound_label, "Sound:");
-    lv_obj_set_style_text_font(sound_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_font(sound_label, &lv_font_montserrat_18, 0);
 
     // Sound dropdown
     s_sound_dropdown = lv_dropdown_create(s_edit_modal);
-    lv_obj_set_width(s_sound_dropdown, 230);
-    lv_obj_set_style_text_font(s_sound_dropdown, &lv_font_montserrat_12, 0);
+    lv_obj_set_width(s_sound_dropdown, 340);
+    lv_obj_set_style_text_font(s_sound_dropdown, &lv_font_montserrat_16, 0);
     update_sound_dropdown();
 
     // Select current sound file
@@ -310,25 +330,26 @@ static void show_edit_dialog(uint8_t index)
 
     // Enable switch row
     lv_obj_t *enable_row = lv_obj_create(s_edit_modal);
-    lv_obj_set_size(enable_row, 230, 40);
+    lv_obj_set_size(enable_row, 340, 50);
     lv_obj_set_flex_flow(enable_row, LV_FLEX_FLOW_ROW);
     lv_obj_set_flex_align(enable_row, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
     lv_obj_set_style_bg_opa(enable_row, LV_OPA_TRANSP, 0);
     lv_obj_set_style_border_width(enable_row, 0, 0);
-    lv_obj_set_style_pad_all(enable_row, 5, 0);
+    lv_obj_set_style_pad_all(enable_row, 10, 0);
 
     lv_obj_t *enable_label = lv_label_create(enable_row);
     lv_label_set_text(enable_label, "Enabled");
-    lv_obj_set_style_text_font(enable_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_font(enable_label, &lv_font_montserrat_18, 0);
 
     s_enable_switch = lv_switch_create(enable_row);
+    lv_obj_set_size(s_enable_switch, 60, 30);
     if (alarm.enabled) {
         lv_obj_add_state(s_enable_switch, LV_STATE_CHECKED);
     }
 
     // Button row
     lv_obj_t *btn_row = lv_obj_create(s_edit_modal);
-    lv_obj_set_size(btn_row, 250, 50);
+    lv_obj_set_size(btn_row, 360, 60);
     lv_obj_set_flex_flow(btn_row, LV_FLEX_FLOW_ROW);
     lv_obj_set_flex_align(btn_row, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
     lv_obj_set_style_bg_opa(btn_row, LV_OPA_TRANSP, 0);
@@ -337,29 +358,32 @@ static void show_edit_dialog(uint8_t index)
 
     // Save button
     lv_obj_t *save_btn = lv_button_create(btn_row);
-    lv_obj_set_size(save_btn, 70, 38);
+    lv_obj_set_size(save_btn, 100, 50);
     lv_obj_add_event_cb(save_btn, save_alarm_cb, LV_EVENT_RELEASED, NULL);
     lv_obj_set_style_bg_color(save_btn, lv_color_hex(0x4CAF50), 0);
     lv_obj_t *save_label = lv_label_create(save_btn);
     lv_label_set_text(save_label, "Save");
+    lv_obj_set_style_text_font(save_label, &lv_font_montserrat_18, 0);
     lv_obj_center(save_label);
 
     // Cancel button
     lv_obj_t *cancel_btn = lv_button_create(btn_row);
-    lv_obj_set_size(cancel_btn, 70, 38);
+    lv_obj_set_size(cancel_btn, 100, 50);
     lv_obj_add_event_cb(cancel_btn, cancel_edit_cb, LV_EVENT_RELEASED, NULL);
     lv_obj_set_style_bg_color(cancel_btn, lv_color_hex(0x757575), 0);
     lv_obj_t *cancel_label = lv_label_create(cancel_btn);
     lv_label_set_text(cancel_label, "Cancel");
+    lv_obj_set_style_text_font(cancel_label, &lv_font_montserrat_18, 0);
     lv_obj_center(cancel_label);
 
     // Delete button
     s_delete_btn = lv_button_create(btn_row);
-    lv_obj_set_size(s_delete_btn, 70, 38);
+    lv_obj_set_size(s_delete_btn, 100, 50);
     lv_obj_add_event_cb(s_delete_btn, delete_alarm_cb, LV_EVENT_RELEASED, NULL);
     lv_obj_set_style_bg_color(s_delete_btn, lv_color_hex(0xF44336), 0);
     lv_obj_t *delete_label = lv_label_create(s_delete_btn);
     lv_label_set_text(delete_label, "Delete");
+    lv_obj_set_style_text_font(delete_label, &lv_font_montserrat_18, 0);
     lv_obj_center(delete_label);
 }
 

--- a/03.firmware/04.integratedAPP/components/ui/ui_alarm.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_alarm.c
@@ -1,0 +1,654 @@
+/**
+ * @file ui_alarm.c
+ * @brief Alarm Settings UI Implementation
+ */
+
+#include "ui_alarm.h"
+#include "alarm.h"
+#include "sdcard.h"
+#include "esp_log.h"
+#include "bsp/jc4880p443c.h"
+#include <stdio.h>
+#include <string.h>
+#include <dirent.h>
+
+static const char *TAG = "UI_ALARM";
+
+// UI element pointers
+static lv_obj_t *s_alarm_panel = NULL;
+static lv_obj_t *s_alarm_title = NULL;
+static lv_obj_t *s_alarm_list = NULL;
+static lv_obj_t *s_add_btn = NULL;
+
+// Edit dialog elements
+static lv_obj_t *s_edit_modal = NULL;
+static lv_obj_t *s_hour_spinbox = NULL;
+static lv_obj_t *s_minute_spinbox = NULL;
+static lv_obj_t *s_day_checkboxes[7] = {NULL};
+static lv_obj_t *s_sound_dropdown = NULL;
+static lv_obj_t *s_enable_switch = NULL;
+static lv_obj_t *s_delete_btn = NULL;
+static uint8_t s_editing_index = 0xFF;
+
+// Trigger popup elements
+static lv_obj_t *s_trigger_popup = NULL;
+static lv_obj_t *s_trigger_time_label = NULL;
+static uint8_t s_triggered_index = 0xFF;
+
+// Sound file list
+#define MAX_SOUND_FILES 16
+static char s_sound_files[MAX_SOUND_FILES][64];
+static int s_sound_file_count = 0;
+
+// Day names
+static const char *DAY_NAMES[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
+
+// ============================================================================
+// Sound File Scanner
+// ============================================================================
+
+static void scan_sound_files(void)
+{
+    s_sound_file_count = 0;
+
+    // Add "Default" option first
+    strcpy(s_sound_files[s_sound_file_count++], "(Default)");
+
+    if (!sdcard_is_available()) {
+        return;
+    }
+
+    DIR *dir = opendir("/sdcard/sounds");
+    if (!dir) {
+        ESP_LOGW(TAG, "Cannot open /sdcard/sounds");
+        return;
+    }
+
+    struct dirent *entry;
+    while ((entry = readdir(dir)) != NULL && s_sound_file_count < MAX_SOUND_FILES) {
+        if (entry->d_type == DT_DIR || entry->d_name[0] == '.') {
+            continue;
+        }
+
+        // Check for .wav extension
+        const char *ext = strrchr(entry->d_name, '.');
+        if (!ext || strcasecmp(ext, ".wav") != 0) {
+            continue;
+        }
+
+        // Skip files with names too long for our buffer
+        if (strlen(entry->d_name) >= 63) {
+            continue;
+        }
+
+        strncpy(s_sound_files[s_sound_file_count], entry->d_name, 63);
+        s_sound_files[s_sound_file_count][63] = '\0';
+        s_sound_file_count++;
+    }
+
+    closedir(dir);
+    ESP_LOGI(TAG, "Found %d sound files", s_sound_file_count - 1);
+}
+
+static void update_sound_dropdown(void)
+{
+    if (!s_sound_dropdown) return;
+
+    scan_sound_files();
+
+    // Build options string
+    static char options[512];
+    options[0] = '\0';
+    int offset = 0;
+
+    for (int i = 0; i < s_sound_file_count; i++) {
+        if (i > 0) {
+            options[offset++] = '\n';
+        }
+        offset += snprintf(options + offset, sizeof(options) - offset, "%s", s_sound_files[i]);
+    }
+
+    lv_dropdown_set_options(s_sound_dropdown, options);
+}
+
+// ============================================================================
+// Edit Dialog
+// ============================================================================
+
+static void close_edit_dialog(void)
+{
+    if (s_edit_modal) {
+        lv_obj_delete(s_edit_modal);
+        s_edit_modal = NULL;
+        s_hour_spinbox = NULL;
+        s_minute_spinbox = NULL;
+        for (int i = 0; i < 7; i++) {
+            s_day_checkboxes[i] = NULL;
+        }
+        s_sound_dropdown = NULL;
+        s_enable_switch = NULL;
+        s_delete_btn = NULL;
+    }
+    s_editing_index = 0xFF;
+}
+
+static void save_alarm_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_RELEASED) return;
+    if (s_editing_index >= ALARM_MAX_COUNT) return;
+
+    alarm_entry_t alarm;
+    memset(&alarm, 0, sizeof(alarm));
+
+    // Get time
+    alarm.hour = (uint8_t)lv_spinbox_get_value(s_hour_spinbox);
+    alarm.minute = (uint8_t)lv_spinbox_get_value(s_minute_spinbox);
+
+    // Get repeat days
+    alarm.repeat_days = 0;
+    for (int i = 0; i < 7; i++) {
+        if (lv_obj_has_state(s_day_checkboxes[i], LV_STATE_CHECKED)) {
+            alarm.repeat_days |= (1 << i);
+        }
+    }
+
+    // Get sound file
+    uint32_t sound_idx = lv_dropdown_get_selected(s_sound_dropdown);
+    if (sound_idx == 0 || sound_idx >= (uint32_t)s_sound_file_count) {
+        // Default sound
+        alarm.sound_path[0] = '\0';
+    } else {
+        snprintf(alarm.sound_path, ALARM_SOUND_PATH_LEN, "/sdcard/sounds/%s",
+                 s_sound_files[sound_idx]);
+    }
+
+    // Get enabled state
+    alarm.enabled = lv_obj_has_state(s_enable_switch, LV_STATE_CHECKED);
+
+    // Save alarm
+    esp_err_t ret = alarm_set(s_editing_index, &alarm);
+    if (ret == ESP_OK) {
+        ESP_LOGI(TAG, "Alarm %d saved", s_editing_index);
+    } else {
+        ESP_LOGW(TAG, "Failed to save alarm: %s", esp_err_to_name(ret));
+    }
+
+    close_edit_dialog();
+    ui_alarm_update_list();
+}
+
+static void cancel_edit_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_RELEASED) return;
+    close_edit_dialog();
+}
+
+static void delete_alarm_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_RELEASED) return;
+    if (s_editing_index >= ALARM_MAX_COUNT) return;
+
+    alarm_delete(s_editing_index);
+    ESP_LOGI(TAG, "Alarm %d deleted", s_editing_index);
+
+    close_edit_dialog();
+    ui_alarm_update_list();
+}
+
+static void show_edit_dialog(uint8_t index)
+{
+    if (s_edit_modal) {
+        close_edit_dialog();
+    }
+
+    s_editing_index = index;
+
+    // Get current alarm data
+    alarm_entry_t alarm;
+    if (alarm_get(index, &alarm) != ESP_OK) {
+        memset(&alarm, 0, sizeof(alarm));
+        alarm.hour = 7;
+        alarm.enabled = true;
+    }
+
+    // Create modal background
+    s_edit_modal = lv_obj_create(lv_screen_active());
+    lv_obj_set_size(s_edit_modal, 280, 420);
+    lv_obj_center(s_edit_modal);
+    lv_obj_set_style_bg_color(s_edit_modal, lv_color_hex(0x1E1E1E), 0);
+    lv_obj_set_style_border_color(s_edit_modal, lv_color_hex(0x444444), 0);
+    lv_obj_set_style_border_width(s_edit_modal, 2, 0);
+    lv_obj_set_style_radius(s_edit_modal, 12, 0);
+    lv_obj_set_style_pad_all(s_edit_modal, 15, 0);
+    lv_obj_set_flex_flow(s_edit_modal, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(s_edit_modal, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_row(s_edit_modal, 10, 0);
+
+    // Title
+    lv_obj_t *title = lv_label_create(s_edit_modal);
+    lv_label_set_text(title, index < ALARM_MAX_COUNT ? "Edit Alarm" : "New Alarm");
+    lv_obj_set_style_text_font(title, &lv_font_montserrat_18, 0);
+
+    // Time row
+    lv_obj_t *time_row = lv_obj_create(s_edit_modal);
+    lv_obj_set_size(time_row, 250, 60);
+    lv_obj_set_flex_flow(time_row, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(time_row, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(time_row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(time_row, 0, 0);
+    lv_obj_set_style_pad_all(time_row, 5, 0);
+    lv_obj_set_style_pad_column(time_row, 10, 0);
+
+    // Hour spinbox
+    s_hour_spinbox = lv_spinbox_create(time_row);
+    lv_spinbox_set_range(s_hour_spinbox, 0, 23);
+    lv_spinbox_set_digit_format(s_hour_spinbox, 2, 0);
+    lv_spinbox_set_value(s_hour_spinbox, alarm.hour);
+    lv_obj_set_width(s_hour_spinbox, 70);
+    lv_obj_set_style_text_font(s_hour_spinbox, &lv_font_montserrat_24, 0);
+
+    // Colon
+    lv_obj_t *colon = lv_label_create(time_row);
+    lv_label_set_text(colon, ":");
+    lv_obj_set_style_text_font(colon, &lv_font_montserrat_24, 0);
+
+    // Minute spinbox
+    s_minute_spinbox = lv_spinbox_create(time_row);
+    lv_spinbox_set_range(s_minute_spinbox, 0, 59);
+    lv_spinbox_set_digit_format(s_minute_spinbox, 2, 0);
+    lv_spinbox_set_value(s_minute_spinbox, alarm.minute);
+    lv_obj_set_width(s_minute_spinbox, 70);
+    lv_obj_set_style_text_font(s_minute_spinbox, &lv_font_montserrat_24, 0);
+
+    // Days label
+    lv_obj_t *days_label = lv_label_create(s_edit_modal);
+    lv_label_set_text(days_label, "Repeat:");
+    lv_obj_set_style_text_font(days_label, &lv_font_montserrat_14, 0);
+
+    // Days row
+    lv_obj_t *days_row = lv_obj_create(s_edit_modal);
+    lv_obj_set_size(days_row, 250, 35);
+    lv_obj_set_flex_flow(days_row, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(days_row, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(days_row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(days_row, 0, 0);
+    lv_obj_set_style_pad_all(days_row, 0, 0);
+
+    for (int i = 0; i < 7; i++) {
+        s_day_checkboxes[i] = lv_checkbox_create(days_row);
+        lv_checkbox_set_text(s_day_checkboxes[i], DAY_NAMES[i]);
+        lv_obj_set_style_text_font(s_day_checkboxes[i], &lv_font_montserrat_12, 0);
+        if (alarm.repeat_days & (1 << i)) {
+            lv_obj_add_state(s_day_checkboxes[i], LV_STATE_CHECKED);
+        }
+    }
+
+    // Sound label
+    lv_obj_t *sound_label = lv_label_create(s_edit_modal);
+    lv_label_set_text(sound_label, "Sound:");
+    lv_obj_set_style_text_font(sound_label, &lv_font_montserrat_14, 0);
+
+    // Sound dropdown
+    s_sound_dropdown = lv_dropdown_create(s_edit_modal);
+    lv_obj_set_width(s_sound_dropdown, 230);
+    lv_obj_set_style_text_font(s_sound_dropdown, &lv_font_montserrat_12, 0);
+    update_sound_dropdown();
+
+    // Select current sound file
+    if (alarm.sound_path[0] != '\0') {
+        const char *filename = strrchr(alarm.sound_path, '/');
+        if (filename) {
+            filename++;  // Skip '/'
+            for (int i = 0; i < s_sound_file_count; i++) {
+                if (strcmp(s_sound_files[i], filename) == 0) {
+                    lv_dropdown_set_selected(s_sound_dropdown, i);
+                    break;
+                }
+            }
+        }
+    }
+
+    // Enable switch row
+    lv_obj_t *enable_row = lv_obj_create(s_edit_modal);
+    lv_obj_set_size(enable_row, 230, 40);
+    lv_obj_set_flex_flow(enable_row, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(enable_row, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(enable_row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(enable_row, 0, 0);
+    lv_obj_set_style_pad_all(enable_row, 5, 0);
+
+    lv_obj_t *enable_label = lv_label_create(enable_row);
+    lv_label_set_text(enable_label, "Enabled");
+    lv_obj_set_style_text_font(enable_label, &lv_font_montserrat_14, 0);
+
+    s_enable_switch = lv_switch_create(enable_row);
+    if (alarm.enabled) {
+        lv_obj_add_state(s_enable_switch, LV_STATE_CHECKED);
+    }
+
+    // Button row
+    lv_obj_t *btn_row = lv_obj_create(s_edit_modal);
+    lv_obj_set_size(btn_row, 250, 50);
+    lv_obj_set_flex_flow(btn_row, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(btn_row, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(btn_row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(btn_row, 0, 0);
+    lv_obj_set_style_pad_all(btn_row, 0, 0);
+
+    // Save button
+    lv_obj_t *save_btn = lv_button_create(btn_row);
+    lv_obj_set_size(save_btn, 70, 38);
+    lv_obj_add_event_cb(save_btn, save_alarm_cb, LV_EVENT_RELEASED, NULL);
+    lv_obj_set_style_bg_color(save_btn, lv_color_hex(0x4CAF50), 0);
+    lv_obj_t *save_label = lv_label_create(save_btn);
+    lv_label_set_text(save_label, "Save");
+    lv_obj_center(save_label);
+
+    // Cancel button
+    lv_obj_t *cancel_btn = lv_button_create(btn_row);
+    lv_obj_set_size(cancel_btn, 70, 38);
+    lv_obj_add_event_cb(cancel_btn, cancel_edit_cb, LV_EVENT_RELEASED, NULL);
+    lv_obj_set_style_bg_color(cancel_btn, lv_color_hex(0x757575), 0);
+    lv_obj_t *cancel_label = lv_label_create(cancel_btn);
+    lv_label_set_text(cancel_label, "Cancel");
+    lv_obj_center(cancel_label);
+
+    // Delete button
+    s_delete_btn = lv_button_create(btn_row);
+    lv_obj_set_size(s_delete_btn, 70, 38);
+    lv_obj_add_event_cb(s_delete_btn, delete_alarm_cb, LV_EVENT_RELEASED, NULL);
+    lv_obj_set_style_bg_color(s_delete_btn, lv_color_hex(0xF44336), 0);
+    lv_obj_t *delete_label = lv_label_create(s_delete_btn);
+    lv_label_set_text(delete_label, "Delete");
+    lv_obj_center(delete_label);
+}
+
+// ============================================================================
+// Alarm List
+// ============================================================================
+
+static void alarm_item_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_RELEASED) return;
+
+    uint8_t *index_ptr = (uint8_t *)lv_event_get_user_data(e);
+    if (index_ptr) {
+        show_edit_dialog(*index_ptr);
+    }
+}
+
+static void add_alarm_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_RELEASED) return;
+
+    // Find first unused slot
+    alarm_entry_t alarms[ALARM_MAX_COUNT];
+    alarm_get_all(alarms);
+
+    for (uint8_t i = 0; i < ALARM_MAX_COUNT; i++) {
+        if (!alarms[i].enabled && alarms[i].hour == 7 && alarms[i].minute == 0 &&
+            alarms[i].repeat_days == 0) {
+            // Empty slot
+            show_edit_dialog(i);
+            return;
+        }
+    }
+
+    // Find first disabled slot
+    for (uint8_t i = 0; i < ALARM_MAX_COUNT; i++) {
+        if (!alarms[i].enabled) {
+            show_edit_dialog(i);
+            return;
+        }
+    }
+
+    ESP_LOGW(TAG, "No free alarm slots");
+}
+
+// Storage for item indices (needed for callbacks)
+static uint8_t s_item_indices[ALARM_MAX_COUNT];
+
+void ui_alarm_update_list(void)
+{
+    if (!s_alarm_list) return;
+
+    // Clear existing items
+    lv_obj_clean(s_alarm_list);
+
+    // Get all alarms
+    alarm_entry_t alarms[ALARM_MAX_COUNT];
+    alarm_get_all(alarms);
+
+    for (uint8_t i = 0; i < ALARM_MAX_COUNT; i++) {
+        // Only show alarms that are enabled or have been configured
+        if (!alarms[i].enabled &&
+            alarms[i].hour == 7 && alarms[i].minute == 0 &&
+            alarms[i].repeat_days == 0) {
+            continue;
+        }
+
+        // Create alarm item
+        lv_obj_t *item = lv_obj_create(s_alarm_list);
+        lv_obj_set_size(item, 210, 50);
+        lv_obj_set_flex_flow(item, LV_FLEX_FLOW_ROW);
+        lv_obj_set_flex_align(item, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+        lv_obj_set_style_bg_color(item, lv_color_hex(0x2D2D2D), 0);
+        lv_obj_set_style_radius(item, 8, 0);
+        lv_obj_set_style_pad_all(item, 8, 0);
+        lv_obj_add_flag(item, LV_OBJ_FLAG_CLICKABLE);
+
+        s_item_indices[i] = i;
+        lv_obj_add_event_cb(item, alarm_item_cb, LV_EVENT_RELEASED, &s_item_indices[i]);
+
+        // Time label
+        char time_str[32];
+        snprintf(time_str, sizeof(time_str), "%02d:%02d", alarms[i].hour, alarms[i].minute);
+        lv_obj_t *time_label = lv_label_create(item);
+        lv_label_set_text(time_label, time_str);
+        lv_obj_set_style_text_font(time_label, &lv_font_montserrat_20, 0);
+        if (!alarms[i].enabled) {
+            lv_obj_set_style_text_color(time_label, lv_color_hex(0x888888), 0);
+        }
+
+        // Days indicator
+        char days_str[24] = "";
+        if (alarms[i].repeat_days == ALARM_REPEAT_ONCE) {
+            strcpy(days_str, "Once");
+        } else if (alarms[i].repeat_days == ALARM_REPEAT_EVERYDAY) {
+            strcpy(days_str, "Daily");
+        } else if (alarms[i].repeat_days == ALARM_REPEAT_WEEKDAYS) {
+            strcpy(days_str, "M-F");
+        } else if (alarms[i].repeat_days == ALARM_REPEAT_WEEKEND) {
+            strcpy(days_str, "S-S");
+        } else {
+            int offset = 0;
+            for (int d = 0; d < 7; d++) {
+                if (alarms[i].repeat_days & (1 << d)) {
+                    if (offset > 0) days_str[offset++] = ',';
+                    days_str[offset++] = DAY_NAMES[d][0];
+                }
+            }
+            days_str[offset] = '\0';
+        }
+
+        lv_obj_t *days_label = lv_label_create(item);
+        lv_label_set_text(days_label, days_str);
+        lv_obj_set_style_text_font(days_label, &lv_font_montserrat_12, 0);
+        lv_obj_set_style_text_color(days_label, lv_color_hex(0xAAAAAA), 0);
+    }
+
+    ESP_LOGD(TAG, "Alarm list updated");
+}
+
+// ============================================================================
+// Trigger Popup
+// ============================================================================
+
+static void dismiss_alarm_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_RELEASED) return;
+
+    alarm_dismiss();
+    ui_alarm_hide_trigger_popup();
+}
+
+static void snooze_alarm_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_RELEASED) return;
+
+    alarm_snooze();
+    ui_alarm_hide_trigger_popup();
+}
+
+void ui_alarm_show_trigger_popup(uint8_t alarm_index)
+{
+    if (s_trigger_popup) {
+        ui_alarm_hide_trigger_popup();
+    }
+
+    s_triggered_index = alarm_index;
+
+    alarm_entry_t alarm;
+    if (alarm_get(alarm_index, &alarm) != ESP_OK) {
+        return;
+    }
+
+    // Create fullscreen popup
+    s_trigger_popup = lv_obj_create(lv_screen_active());
+    lv_obj_set_size(s_trigger_popup, LV_PCT(100), LV_PCT(100));
+    lv_obj_center(s_trigger_popup);
+    lv_obj_set_style_bg_color(s_trigger_popup, lv_color_hex(0x1A1A2E), 0);
+    lv_obj_set_style_bg_opa(s_trigger_popup, LV_OPA_COVER, 0);
+    lv_obj_set_style_border_width(s_trigger_popup, 0, 0);
+    lv_obj_set_flex_flow(s_trigger_popup, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(s_trigger_popup, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_row(s_trigger_popup, 30, 0);
+
+    // Alarm icon
+    lv_obj_t *icon = lv_label_create(s_trigger_popup);
+    lv_label_set_text(icon, LV_SYMBOL_BELL);
+    lv_obj_set_style_text_font(icon, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_color(icon, lv_color_hex(0xFFD700), 0);
+
+    // Time display
+    s_trigger_time_label = lv_label_create(s_trigger_popup);
+    char time_str[16];
+    snprintf(time_str, sizeof(time_str), "%02d:%02d", alarm.hour, alarm.minute);
+    lv_label_set_text(s_trigger_time_label, time_str);
+    lv_obj_set_style_text_font(s_trigger_time_label, &lv_font_montserrat_24, 0);
+
+    // Alarm label
+    lv_obj_t *label = lv_label_create(s_trigger_popup);
+    lv_label_set_text(label, "ALARM");
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_24, 0);
+
+    // Button container
+    lv_obj_t *btn_container = lv_obj_create(s_trigger_popup);
+    lv_obj_set_size(btn_container, 280, 60);
+    lv_obj_set_flex_flow(btn_container, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(btn_container, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(btn_container, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(btn_container, 0, 0);
+    lv_obj_set_style_pad_all(btn_container, 0, 0);
+
+    // Snooze button
+    lv_obj_t *snooze_btn = lv_button_create(btn_container);
+    lv_obj_set_size(snooze_btn, 120, 50);
+    lv_obj_add_event_cb(snooze_btn, snooze_alarm_cb, LV_EVENT_RELEASED, NULL);
+    lv_obj_set_style_bg_color(snooze_btn, lv_color_hex(0xFF9800), 0);
+    lv_obj_t *snooze_label = lv_label_create(snooze_btn);
+    lv_label_set_text(snooze_label, "Snooze");
+    lv_obj_set_style_text_font(snooze_label, &lv_font_montserrat_18, 0);
+    lv_obj_center(snooze_label);
+
+    // Dismiss button
+    lv_obj_t *dismiss_btn = lv_button_create(btn_container);
+    lv_obj_set_size(dismiss_btn, 120, 50);
+    lv_obj_add_event_cb(dismiss_btn, dismiss_alarm_cb, LV_EVENT_RELEASED, NULL);
+    lv_obj_set_style_bg_color(dismiss_btn, lv_color_hex(0x4CAF50), 0);
+    lv_obj_t *dismiss_label = lv_label_create(dismiss_btn);
+    lv_label_set_text(dismiss_label, "Dismiss");
+    lv_obj_set_style_text_font(dismiss_label, &lv_font_montserrat_18, 0);
+    lv_obj_center(dismiss_label);
+
+    ESP_LOGI(TAG, "Showing alarm trigger popup for alarm %d", alarm_index);
+}
+
+void ui_alarm_hide_trigger_popup(void)
+{
+    if (s_trigger_popup) {
+        lv_obj_delete(s_trigger_popup);
+        s_trigger_popup = NULL;
+        s_trigger_time_label = NULL;
+    }
+    s_triggered_index = 0xFF;
+}
+
+bool ui_alarm_is_popup_visible(void)
+{
+    return s_trigger_popup != NULL;
+}
+
+// ============================================================================
+// Public API
+// ============================================================================
+
+void ui_alarm_init(lv_obj_t *parent)
+{
+    if (!parent) return;
+
+    // Create alarm settings section
+    s_alarm_panel = lv_obj_create(parent);
+    lv_obj_set_size(s_alarm_panel, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_flex_flow(s_alarm_panel, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(s_alarm_panel, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(s_alarm_panel, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(s_alarm_panel, 0, 0);
+    lv_obj_set_style_pad_all(s_alarm_panel, 0, 0);
+    lv_obj_set_style_pad_row(s_alarm_panel, 8, 0);
+
+    // Title
+    s_alarm_title = lv_label_create(s_alarm_panel);
+    lv_label_set_text(s_alarm_title, "Alarms");
+    lv_obj_set_style_text_font(s_alarm_title, &lv_font_montserrat_18, 0);
+
+    // Alarm list container
+    s_alarm_list = lv_obj_create(s_alarm_panel);
+    lv_obj_set_size(s_alarm_list, 230, 180);
+    lv_obj_set_flex_flow(s_alarm_list, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(s_alarm_list, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_color(s_alarm_list, lv_color_hex(0x252525), 0);
+    lv_obj_set_style_radius(s_alarm_list, 8, 0);
+    lv_obj_set_style_pad_all(s_alarm_list, 8, 0);
+    lv_obj_set_style_pad_row(s_alarm_list, 6, 0);
+    lv_obj_add_flag(s_alarm_list, LV_OBJ_FLAG_SCROLLABLE);
+
+    // Add button
+    s_add_btn = lv_button_create(s_alarm_panel);
+    lv_obj_set_size(s_add_btn, 180, 40);
+    lv_obj_add_event_cb(s_add_btn, add_alarm_cb, LV_EVENT_RELEASED, NULL);
+    lv_obj_set_style_bg_color(s_add_btn, lv_color_hex(0x2196F3), 0);
+
+    lv_obj_t *add_label = lv_label_create(s_add_btn);
+    lv_label_set_text(add_label, LV_SYMBOL_PLUS " Add Alarm");
+    lv_obj_set_style_text_font(add_label, &lv_font_montserrat_14, 0);
+    lv_obj_center(add_label);
+
+    // Initial update
+    ui_alarm_update_list();
+
+    ESP_LOGI(TAG, "Alarm UI initialized");
+}
+
+void ui_alarm_deinit(void)
+{
+    close_edit_dialog();
+    ui_alarm_hide_trigger_popup();
+
+    s_alarm_panel = NULL;
+    s_alarm_title = NULL;
+    s_alarm_list = NULL;
+    s_add_btn = NULL;
+
+    ESP_LOGI(TAG, "Alarm UI deinitialized");
+}

--- a/03.firmware/04.integratedAPP/components/ui/ui_alarm.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_alarm.c
@@ -284,17 +284,47 @@ static void show_edit_dialog(uint8_t index)
     lv_label_set_text(days_label, "Repeat Days:");
     lv_obj_set_style_text_font(days_label, &lv_font_montserrat_18, 0);
 
-    // Days row
-    lv_obj_t *days_row = lv_obj_create(s_edit_modal);
-    lv_obj_set_size(days_row, 360, 50);
-    lv_obj_set_flex_flow(days_row, LV_FLEX_FLOW_ROW);
-    lv_obj_set_flex_align(days_row, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-    lv_obj_set_style_bg_opa(days_row, LV_OPA_TRANSP, 0);
-    lv_obj_set_style_border_width(days_row, 0, 0);
-    lv_obj_set_style_pad_all(days_row, 0, 0);
+    // Days container (2 rows)
+    lv_obj_t *days_container = lv_obj_create(s_edit_modal);
+    lv_obj_set_size(days_container, 360, 90);
+    lv_obj_set_flex_flow(days_container, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(days_container, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(days_container, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(days_container, 0, 0);
+    lv_obj_set_style_pad_all(days_container, 0, 0);
+    lv_obj_set_style_pad_row(days_container, 8, 0);
 
+    // Row 1: Mon-Fri
+    lv_obj_t *days_row1 = lv_obj_create(days_container);
+    lv_obj_set_size(days_row1, 360, 40);
+    lv_obj_set_flex_flow(days_row1, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(days_row1, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(days_row1, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(days_row1, 0, 0);
+    lv_obj_set_style_pad_all(days_row1, 0, 0);
+
+    // Row 2: Sat-Sun
+    lv_obj_t *days_row2 = lv_obj_create(days_container);
+    lv_obj_set_size(days_row2, 360, 40);
+    lv_obj_set_flex_flow(days_row2, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(days_row2, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(days_row2, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(days_row2, 0, 0);
+    lv_obj_set_style_pad_all(days_row2, 0, 0);
+    lv_obj_set_style_pad_column(days_row2, 30, 0);
+
+    // Create checkboxes: Mon-Fri on row1, Sat-Sun on row2
+    // DAY_NAMES order: Sun(0), Mon(1), Tue(2), Wed(3), Thu(4), Fri(5), Sat(6)
     for (int i = 0; i < 7; i++) {
-        s_day_checkboxes[i] = lv_checkbox_create(days_row);
+        lv_obj_t *parent_row;
+        if (i == 0 || i == 6) {
+            // Sunday (0) and Saturday (6) go to row 2
+            parent_row = days_row2;
+        } else {
+            // Mon-Fri go to row 1
+            parent_row = days_row1;
+        }
+        s_day_checkboxes[i] = lv_checkbox_create(parent_row);
         lv_checkbox_set_text(s_day_checkboxes[i], DAY_NAMES[i]);
         lv_obj_set_style_text_font(s_day_checkboxes[i], &lv_font_montserrat_14, 0);
         lv_obj_set_style_text_color(s_day_checkboxes[i], lv_color_hex(0xFFFFFF), 0);

--- a/03.firmware/04.integratedAPP/components/ui/ui_alarm.h
+++ b/03.firmware/04.integratedAPP/components/ui/ui_alarm.h
@@ -1,0 +1,63 @@
+/**
+ * @file ui_alarm.h
+ * @brief Alarm Settings UI API
+ *
+ * Provides alarm configuration screen and trigger popup.
+ */
+
+#pragma once
+
+#include "lvgl.h"
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize alarm UI
+ *
+ * Creates alarm settings UI in the settings panel.
+ *
+ * @param parent Parent container (settings panel)
+ */
+void ui_alarm_init(lv_obj_t *parent);
+
+/**
+ * @brief Deinitialize alarm UI
+ *
+ * Cleans up UI elements.
+ */
+void ui_alarm_deinit(void);
+
+/**
+ * @brief Update alarm list display
+ *
+ * Refreshes the alarm list with current alarm data.
+ */
+void ui_alarm_update_list(void);
+
+/**
+ * @brief Show alarm trigger popup
+ *
+ * Displays full-screen alarm popup with dismiss/snooze buttons.
+ *
+ * @param alarm_index Index of triggered alarm
+ */
+void ui_alarm_show_trigger_popup(uint8_t alarm_index);
+
+/**
+ * @brief Hide alarm trigger popup
+ */
+void ui_alarm_hide_trigger_popup(void);
+
+/**
+ * @brief Check if trigger popup is visible
+ *
+ * @return true if popup is visible
+ */
+bool ui_alarm_is_popup_visible(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/03.firmware/04.integratedAPP/components/ui/ui_navigation.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_navigation.c
@@ -1518,11 +1518,13 @@ static void setup_settings_nav(void)
         // Register BLE event callback
         ble_hid_register_callback(ble_event_callback);
 
-        // Configure Panel43 for vertical layout
+        // Configure Panel43 for vertical layout with scrolling
         lv_obj_set_flex_flow(ui_Panel43, LV_FLEX_FLOW_COLUMN);
         lv_obj_set_flex_align(ui_Panel43, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
         lv_obj_set_style_pad_row(ui_Panel43, 12, 0);
         lv_obj_set_style_pad_top(ui_Panel43, 15, 0);
+        lv_obj_set_style_pad_bottom(ui_Panel43, 30, 0);  // Bottom padding for scroll
+        lv_obj_add_flag(ui_Panel43, LV_OBJ_FLAG_SCROLLABLE);  // Enable scrolling
 
         // BLE Section Title
         lv_obj_t *ble_title = lv_label_create(ui_Panel43);

--- a/03.firmware/04.integratedAPP/components/ui/ui_navigation.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_navigation.c
@@ -30,6 +30,10 @@
 #include "bsp/touch.h"
 #include "esp_lcd_touch.h"
 
+// Alarm UI
+#include "ui_alarm.h"
+#include "alarm.h"
+
 static const char *TAG = "UI_NAV";
 
 // ============================================================================
@@ -206,6 +210,10 @@ static int g_bonded_count = 0;
 // BLE state for UI updates (volatile for cross-task visibility)
 static volatile ble_hid_state_t g_ble_ui_state = BLE_HID_STATE_IDLE;
 static volatile bool g_ble_state_changed = false;
+
+// Alarm state for UI updates (volatile for cross-task visibility)
+static volatile bool g_alarm_triggered = false;
+static volatile uint8_t g_alarm_triggered_index = 0xFF;
 
 // ============================================================================
 // Navigation Callbacks
@@ -1199,6 +1207,27 @@ static void ble_event_callback(ble_hid_state_t state)
 }
 
 /**
+ * @brief Alarm event callback (called from alarm check)
+ */
+static void alarm_event_callback(alarm_event_t event, uint8_t index, void *user_data)
+{
+    (void)user_data;
+
+    if (event == ALARM_EVENT_TRIGGERED) {
+        g_alarm_triggered = true;
+        g_alarm_triggered_index = index;
+        ESP_LOGI(TAG, "Alarm event: triggered, index=%d", index);
+    } else if (event == ALARM_EVENT_DISMISSED || event == ALARM_EVENT_SNOOZED ||
+               event == ALARM_EVENT_EXPIRED) {
+        g_alarm_triggered = false;
+        g_alarm_triggered_index = 0xFF;
+        ESP_LOGI(TAG, "Alarm event: %s, index=%d",
+                 event == ALARM_EVENT_DISMISSED ? "dismissed" :
+                 event == ALARM_EVENT_SNOOZED ? "snoozed" : "expired", index);
+    }
+}
+
+/**
  * @brief Connect/disconnect button callback
  */
 static void ble_connect_btn_cb(lv_event_t *e)
@@ -1372,6 +1401,23 @@ static void setup_settings_nav(void)
         ESP_LOGI(TAG, "BLE settings UI created");
     }
 
+    // Create Alarm settings UI (below BLE settings)
+    static bool alarm_ui_created = false;
+    if (ui_Panel43 && !alarm_ui_created) {
+        // Add separator
+        lv_obj_t *separator = lv_obj_create(ui_Panel43);
+        lv_obj_set_size(separator, 200, 2);
+        lv_obj_set_style_bg_color(separator, lv_color_hex(0x444444), 0);
+        lv_obj_set_style_border_width(separator, 0, 0);
+        lv_obj_set_style_pad_all(separator, 0, 0);
+
+        // Initialize alarm UI in the settings panel
+        ui_alarm_init(ui_Panel43);
+        alarm_ui_created = true;
+
+        ESP_LOGI(TAG, "Alarm settings UI created");
+    }
+
     last_settings_screen = ui_SettingScreen;
     ESP_LOGD(TAG, "Settings nav ready");
 }
@@ -1418,6 +1464,11 @@ static void nav_timer_cb(lv_timer_t *timer)
         g_ble_state_changed = false;
         update_ble_status_ui();
     }
+
+    // Check for alarm trigger and show popup (thread-safe via LVGL timer)
+    if (g_alarm_triggered && !ui_alarm_is_popup_visible()) {
+        ui_alarm_show_trigger_popup(g_alarm_triggered_index);
+    }
 }
 
 // ============================================================================
@@ -1454,6 +1505,9 @@ void ui_navigation_init(void)
 
     // Timer for lazy screen navigation setup
     lv_timer_create(nav_timer_cb, 100, NULL);
+
+    // Register alarm event callback for UI updates
+    alarm_register_callback(alarm_event_callback, NULL);
 
     ESP_LOGI(TAG, "Navigation initialized");
 }

--- a/03.firmware/04.integratedAPP/components/ui/ui_navigation.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_navigation.c
@@ -34,6 +34,10 @@
 #include "ui_alarm.h"
 #include "alarm.h"
 
+// Background settings
+#include "sdcard.h"
+#include "ui_background.h"
+
 static const char *TAG = "UI_NAV";
 
 // ============================================================================
@@ -214,6 +218,16 @@ static volatile bool g_ble_state_changed = false;
 // Alarm state for UI updates (volatile for cross-task visibility)
 static volatile bool g_alarm_triggered = false;
 static volatile uint8_t g_alarm_triggered_index = 0xFF;
+
+// Background Settings UI elements
+static lv_obj_t *bg_touchpad_dropdown = NULL;
+static lv_obj_t *bg_clock_dropdown = NULL;
+static bool bg_ui_created = false;
+
+// Background file list storage
+#define MAX_BG_FILES 32
+static sdcard_file_t s_bg_files[MAX_BG_FILES];
+static size_t s_bg_file_count = 0;
 
 // ============================================================================
 // Navigation Callbacks
@@ -1291,6 +1305,184 @@ static void ble_clear_bonds_cb(lv_event_t *e)
     update_ble_status_ui();
 }
 
+// ============================================================================
+// Background Settings Functions
+// ============================================================================
+
+/**
+ * @brief Scan background files from SD card and update dropdown options
+ */
+static void update_bg_dropdown_options(void)
+{
+    if (!sdcard_is_available()) {
+        s_bg_file_count = 0;
+        return;
+    }
+
+    esp_err_t ret = sdcard_list_backgrounds(s_bg_files, MAX_BG_FILES, &s_bg_file_count);
+    if (ret != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to list backgrounds: %s", esp_err_to_name(ret));
+        s_bg_file_count = 0;
+    }
+
+    ESP_LOGI(TAG, "Found %zu background files", s_bg_file_count);
+}
+
+/**
+ * @brief Build dropdown options string from file list
+ */
+static void build_bg_options_string(char *buf, size_t buf_len, bool include_default)
+{
+    int offset = 0;
+
+    // First option
+    if (include_default) {
+        offset += snprintf(buf + offset, buf_len - offset, "Default");
+    } else {
+        offset += snprintf(buf + offset, buf_len - offset, "None");
+    }
+
+    // Add files
+    for (size_t i = 0; i < s_bg_file_count && offset < (int)buf_len - 1; i++) {
+        offset += snprintf(buf + offset, buf_len - offset, "\n%s", s_bg_files[i].filename);
+    }
+}
+
+/**
+ * @brief Find dropdown index for current background path
+ */
+static uint32_t find_bg_index(const char *current_path)
+{
+    if (!current_path || current_path[0] == '\0') {
+        return 0;  // None/Default
+    }
+
+    for (size_t i = 0; i < s_bg_file_count; i++) {
+        if (strcmp(s_bg_files[i].full_path, current_path) == 0) {
+            return i + 1;  // +1 because index 0 is None/Default
+        }
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Touchpad background dropdown callback
+ */
+static void bg_touchpad_changed_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
+
+    uint32_t idx = lv_dropdown_get_selected(bg_touchpad_dropdown);
+
+    if (idx == 0) {
+        // None selected
+        sdcard_set_touchpad_bg(SDCARD_BG_NONE);
+        ui_bg_clear_touchpad();
+        ESP_LOGI(TAG, "Touchpad background cleared");
+    } else if (idx <= s_bg_file_count) {
+        const char *path = s_bg_files[idx - 1].full_path;
+        sdcard_set_touchpad_bg(path);
+        ui_bg_apply_to_touchpad(path);
+        ESP_LOGI(TAG, "Touchpad background set: %s", path);
+    }
+}
+
+/**
+ * @brief Clock background dropdown callback
+ */
+static void bg_clock_changed_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
+
+    uint32_t idx = lv_dropdown_get_selected(bg_clock_dropdown);
+
+    if (idx == 0) {
+        // Default selected
+        sdcard_set_clock_bg(SDCARD_BG_NONE);
+        ui_bg_clear_clock();
+        ESP_LOGI(TAG, "Clock background set to default");
+    } else if (idx <= s_bg_file_count) {
+        const char *path = s_bg_files[idx - 1].full_path;
+        sdcard_set_clock_bg(path);
+        ui_bg_apply_to_clock(path);
+        ESP_LOGI(TAG, "Clock background set: %s", path);
+    }
+}
+
+/**
+ * @brief Create background settings UI
+ */
+static void create_bg_settings_ui(lv_obj_t *parent)
+{
+    // Scan files first
+    update_bg_dropdown_options();
+
+    // Background Settings Title
+    lv_obj_t *bg_title = lv_label_create(parent);
+    lv_label_set_text(bg_title, "Background Settings");
+    lv_obj_set_style_text_font(bg_title, &lv_font_montserrat_18, 0);
+
+    // SD card status
+    lv_obj_t *sd_status = lv_label_create(parent);
+    if (sdcard_is_available()) {
+        char status_text[64];
+        snprintf(status_text, sizeof(status_text), "SD Card: %zu files found", s_bg_file_count);
+        lv_label_set_text(sd_status, status_text);
+        lv_obj_set_style_text_color(sd_status, lv_color_hex(0x00FF00), 0);
+    } else {
+        lv_label_set_text(sd_status, "SD Card: Not available");
+        lv_obj_set_style_text_color(sd_status, lv_color_hex(0xFF6666), 0);
+    }
+    lv_obj_set_style_text_font(sd_status, &lv_font_montserrat_14, 0);
+
+    // Touchpad background label
+    lv_obj_t *tp_label = lv_label_create(parent);
+    lv_label_set_text(tp_label, "Touchpad Background:");
+    lv_obj_set_style_text_font(tp_label, &lv_font_montserrat_14, 0);
+
+    // Touchpad background dropdown
+    bg_touchpad_dropdown = lv_dropdown_create(parent);
+    lv_obj_set_width(bg_touchpad_dropdown, 280);
+    lv_obj_set_style_text_font(bg_touchpad_dropdown, &lv_font_montserrat_14, 0);
+
+    static char tp_options[1024];
+    build_bg_options_string(tp_options, sizeof(tp_options), false);
+    lv_dropdown_set_options(bg_touchpad_dropdown, tp_options);
+
+    // Select current touchpad background
+    char current_tp_bg[128] = {0};
+    if (sdcard_get_touchpad_bg(current_tp_bg, sizeof(current_tp_bg)) == ESP_OK) {
+        lv_dropdown_set_selected(bg_touchpad_dropdown, find_bg_index(current_tp_bg));
+    }
+
+    lv_obj_add_event_cb(bg_touchpad_dropdown, bg_touchpad_changed_cb, LV_EVENT_VALUE_CHANGED, NULL);
+
+    // Clock background label
+    lv_obj_t *clock_label = lv_label_create(parent);
+    lv_label_set_text(clock_label, "Clock Background:");
+    lv_obj_set_style_text_font(clock_label, &lv_font_montserrat_14, 0);
+
+    // Clock background dropdown
+    bg_clock_dropdown = lv_dropdown_create(parent);
+    lv_obj_set_width(bg_clock_dropdown, 280);
+    lv_obj_set_style_text_font(bg_clock_dropdown, &lv_font_montserrat_14, 0);
+
+    static char clock_options[1024];
+    build_bg_options_string(clock_options, sizeof(clock_options), true);
+    lv_dropdown_set_options(bg_clock_dropdown, clock_options);
+
+    // Select current clock background
+    char current_clock_bg[128] = {0};
+    if (sdcard_get_clock_bg(current_clock_bg, sizeof(current_clock_bg)) == ESP_OK) {
+        lv_dropdown_set_selected(bg_clock_dropdown, find_bg_index(current_clock_bg));
+    }
+
+    lv_obj_add_event_cb(bg_clock_dropdown, bg_clock_changed_cb, LV_EVENT_VALUE_CHANGED, NULL);
+
+    ESP_LOGI(TAG, "Background settings UI created");
+}
+
 static void setup_settings_nav(void)
 {
     // Create elements only if screen changed (destroyed and recreated)
@@ -1302,6 +1494,9 @@ static void setup_settings_nav(void)
         ble_connect_label = NULL;
         ble_delete_btn = NULL;
         ble_clear_btn = NULL;
+        bg_touchpad_dropdown = NULL;
+        bg_clock_dropdown = NULL;
+        bg_ui_created = false;
     }
 
     if (ui_SettingScreen && !setting_back_btn) {
@@ -1416,6 +1611,20 @@ static void setup_settings_nav(void)
         alarm_ui_created = true;
 
         ESP_LOGI(TAG, "Alarm settings UI created");
+    }
+
+    // Create Background settings UI (below Alarm settings)
+    if (ui_Panel43 && !bg_ui_created) {
+        // Add separator
+        lv_obj_t *separator2 = lv_obj_create(ui_Panel43);
+        lv_obj_set_size(separator2, 200, 2);
+        lv_obj_set_style_bg_color(separator2, lv_color_hex(0x444444), 0);
+        lv_obj_set_style_border_width(separator2, 0, 0);
+        lv_obj_set_style_pad_all(separator2, 0, 0);
+
+        // Initialize background settings UI
+        create_bg_settings_ui(ui_Panel43);
+        bg_ui_created = true;
     }
 
     last_settings_screen = ui_SettingScreen;

--- a/03.firmware/04.integratedAPP/components/ui/ui_navigation.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_navigation.c
@@ -1422,6 +1422,7 @@ static void create_bg_settings_ui(lv_obj_t *parent)
     lv_obj_t *bg_title = lv_label_create(parent);
     lv_label_set_text(bg_title, "Background Settings");
     lv_obj_set_style_text_font(bg_title, &lv_font_montserrat_18, 0);
+    lv_obj_set_style_text_color(bg_title, lv_color_hex(0xFFFFFF), 0);
 
     // SD card status
     lv_obj_t *sd_status = lv_label_create(parent);
@@ -1440,6 +1441,7 @@ static void create_bg_settings_ui(lv_obj_t *parent)
     lv_obj_t *tp_label = lv_label_create(parent);
     lv_label_set_text(tp_label, "Touchpad Background:");
     lv_obj_set_style_text_font(tp_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(tp_label, lv_color_hex(0xFFFFFF), 0);
 
     // Touchpad background dropdown
     bg_touchpad_dropdown = lv_dropdown_create(parent);
@@ -1462,6 +1464,7 @@ static void create_bg_settings_ui(lv_obj_t *parent)
     lv_obj_t *clock_label = lv_label_create(parent);
     lv_label_set_text(clock_label, "Clock Background:");
     lv_obj_set_style_text_font(clock_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(clock_label, lv_color_hex(0xFFFFFF), 0);
 
     // Clock background dropdown
     bg_clock_dropdown = lv_dropdown_create(parent);

--- a/03.firmware/04.integratedAPP/main/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/main/CMakeLists.txt
@@ -13,4 +13,5 @@ idf_component_register(
         ui
         ble_hid
         sdcard
+        alarm
 )

--- a/03.firmware/04.integratedAPP/main/main.c
+++ b/03.firmware/04.integratedAPP/main/main.c
@@ -44,6 +44,9 @@
 #include "sdcard.h"
 #include "ui_background.h"
 
+// Alarm
+#include "alarm.h"
+
 static const char *TAG = "HANDY_KEYBOARD";
 
 // LVGL display handle
@@ -139,6 +142,9 @@ static void rtc_update_task(void *pvParameters)
             time(&now);
             localtime_r(&now, &time_info);
 
+            // Check alarm triggers (called every second)
+            alarm_check_time(&time_info);
+
             // Update clock hands (with LVGL lock)
             if (bsp_display_lock(100)) {
                 ui_clock_update_hands(time_info.tm_hour, time_info.tm_min, time_info.tm_sec);
@@ -217,6 +223,15 @@ void app_main(void)
 
     // Initialize RTC using BSP I2C handle
     rtc_init();
+
+    // Initialize alarm system (uses audio player and NVS)
+    ESP_LOGI(TAG, "Initializing alarm system...");
+    esp_err_t alarm_ret = alarm_init();
+    if (alarm_ret != ESP_OK) {
+        ESP_LOGW(TAG, "Alarm init failed: %s", esp_err_to_name(alarm_ret));
+    } else {
+        ESP_LOGI(TAG, "Alarm system initialized");
+    }
 
     // Initialize SquareLine Studio UI, navigation, and customization
     if (bsp_display_lock(1000)) {


### PR DESCRIPTION
## Summary
- 最大8件のアラームを設定可能（NVS永続化）
- SDカードからカスタムアラーム音を指定可能（WAV形式）
- リピート設定（毎日、平日、週末、1回のみ）
- スヌーズ機能（5分）、自動停止（5分後）
- 設定画面UIとトリガーポップアップを追加

## New Components
| コンポーネント | 説明 |
|--------------|------|
| `alarm` | アラーム管理（時間チェック、NVS保存） |
| `audio_player` | WAV再生（ES8311コーデック経由） |
| `ui_alarm` | LVGL設定UI + トリガーポップアップ |

## Test plan
- [ ] ビルド確認: `idf.py build` が成功すること
- [ ] アラーム追加: 設定画面からアラームを追加できること
- [ ] アラーム編集: 時刻、リピート、サウンドを変更できること
- [ ] アラーム削除: アラームを削除できること
- [ ] トリガー: 設定時刻にアラームが鳴ること
- [ ] スヌーズ: スヌーズボタンで5分後に再トリガーすること
- [ ] 停止: 停止ボタンでアラームが止まること
- [ ] カスタム音: `/sdcard/sounds/*.wav` からカスタム音を選択できること

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)