### PR TITLE
feat: add shared JPEG decoder and double buffering for MJPEG player

### DIFF
--- a/03.firmware/04.integratedAPP/components/common/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/components/common/CMakeLists.txt
@@ -2,9 +2,11 @@ idf_component_register(
     SRCS
         "src/logger.c"
         "src/event_queue.c"
+        "src/shared_jpeg_decoder.c"
     INCLUDE_DIRS
         "include"
     REQUIRES
         freertos
         esp_timer
+        esp_driver_jpeg
 )

--- a/03.firmware/04.integratedAPP/components/common/include/shared_jpeg_decoder.h
+++ b/03.firmware/04.integratedAPP/components/common/include/shared_jpeg_decoder.h
@@ -1,0 +1,81 @@
+/**
+ * @file shared_jpeg_decoder.h
+ * @brief Shared Hardware JPEG Decoder for ESP32-P4
+ *
+ * Provides a singleton JPEG decoder instance shared between ui_background
+ * and mjpeg_player components. The ESP32-P4 hardware JPEG decoder requires
+ * internal DMA memory, so sharing a single instance conserves memory.
+ *
+ * Usage:
+ * 1. Call shared_jpeg_decoder_init() early in main() before display init
+ * 2. Use shared_jpeg_decoder_lock() before decode operations
+ * 3. Get handle with shared_jpeg_decoder_get_handle()
+ * 4. Call shared_jpeg_decoder_unlock() after decode completes
+ */
+
+#pragma once
+
+#include "esp_err.h"
+#include "driver/jpeg_decode.h"
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize the shared hardware JPEG decoder
+ *
+ * This must be called EARLY in system initialization (before display init),
+ * when internal DMA memory is still available. The hardware JPEG decoder
+ * requires internal DMA-capable memory for its descriptor chains.
+ *
+ * Safe to call multiple times - subsequent calls are no-ops.
+ *
+ * @return
+ *     - ESP_OK: Success (or already initialized)
+ *     - ESP_ERR_NO_MEM: Not enough internal DMA memory
+ */
+esp_err_t shared_jpeg_decoder_init(void);
+
+/**
+ * @brief Get the shared JPEG decoder handle
+ *
+ * Returns the singleton decoder handle. Must call shared_jpeg_decoder_lock()
+ * before using the handle, and shared_jpeg_decoder_unlock() after.
+ *
+ * @return JPEG decoder handle, or NULL if not initialized
+ */
+jpeg_decoder_handle_t shared_jpeg_decoder_get_handle(void);
+
+/**
+ * @brief Lock the shared decoder for exclusive use
+ *
+ * Must be called before any decode operation to ensure thread safety.
+ * The decoder is shared between ui_background (static JPEG) and
+ * mjpeg_player (video frames).
+ *
+ * @param timeout_ms Maximum time to wait for lock (milliseconds)
+ * @return true if lock acquired, false on timeout
+ */
+bool shared_jpeg_decoder_lock(uint32_t timeout_ms);
+
+/**
+ * @brief Unlock the shared decoder
+ *
+ * Must be called after decode operation completes to allow other
+ * components to use the decoder.
+ */
+void shared_jpeg_decoder_unlock(void);
+
+/**
+ * @brief Check if the shared decoder is initialized
+ *
+ * @return true if initialized and ready for use
+ */
+bool shared_jpeg_decoder_is_initialized(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/03.firmware/04.integratedAPP/components/common/src/shared_jpeg_decoder.c
+++ b/03.firmware/04.integratedAPP/components/common/src/shared_jpeg_decoder.c
@@ -1,0 +1,80 @@
+/**
+ * @file shared_jpeg_decoder.c
+ * @brief Shared Hardware JPEG Decoder Implementation
+ *
+ * Singleton JPEG decoder shared between ui_background and mjpeg_player.
+ * Uses ESP32-P4 hardware JPEG decoder for fast decoding.
+ */
+
+#include "shared_jpeg_decoder.h"
+#include "esp_log.h"
+#include "esp_heap_caps.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+
+static const char *TAG = "SHARED_JPEG";
+
+// Singleton decoder instance
+static jpeg_decoder_handle_t s_decoder = NULL;
+static SemaphoreHandle_t s_mutex = NULL;
+
+esp_err_t shared_jpeg_decoder_init(void)
+{
+    // Create mutex if not exists
+    if (s_mutex == NULL) {
+        s_mutex = xSemaphoreCreateMutex();
+        if (s_mutex == NULL) {
+            ESP_LOGE(TAG, "Failed to create mutex");
+            return ESP_ERR_NO_MEM;
+        }
+    }
+
+    // Already initialized
+    if (s_decoder != NULL) {
+        ESP_LOGD(TAG, "Shared JPEG decoder already initialized");
+        return ESP_OK;
+    }
+
+    // Log available internal DMA memory before allocation
+    size_t free_dma = heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
+    ESP_LOGI(TAG, "Free internal DMA memory before JPEG init: %u bytes", free_dma);
+
+    // Create hardware JPEG decoder
+    jpeg_decode_engine_cfg_t decode_eng_cfg = {
+        .timeout_ms = 100,
+    };
+    esp_err_t ret = jpeg_new_decoder_engine(&decode_eng_cfg, &s_decoder);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to create JPEG decoder: %s", esp_err_to_name(ret));
+        ESP_LOGE(TAG, "Free internal DMA memory: %u bytes (may need more for rxlink)", free_dma);
+        return ret;
+    }
+
+    ESP_LOGI(TAG, "Hardware JPEG decoder initialized successfully");
+    return ESP_OK;
+}
+
+jpeg_decoder_handle_t shared_jpeg_decoder_get_handle(void)
+{
+    return s_decoder;
+}
+
+bool shared_jpeg_decoder_lock(uint32_t timeout_ms)
+{
+    if (s_mutex == NULL) {
+        return false;
+    }
+    return xSemaphoreTake(s_mutex, pdMS_TO_TICKS(timeout_ms)) == pdTRUE;
+}
+
+void shared_jpeg_decoder_unlock(void)
+{
+    if (s_mutex != NULL) {
+        xSemaphoreGive(s_mutex);
+    }
+}
+
+bool shared_jpeg_decoder_is_initialized(void)
+{
+    return s_decoder != NULL;
+}

--- a/03.firmware/04.integratedAPP/components/mjpeg_player/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/components/mjpeg_player/CMakeLists.txt
@@ -1,6 +1,6 @@
 idf_component_register(
     SRCS "src/mjpeg_player.c"
     INCLUDE_DIRS "include"
-    REQUIRES lvgl esp_driver_jpeg freertos
+    REQUIRES lvgl esp_driver_jpeg freertos common
     PRIV_REQUIRES bsp_jc4880p443c
 )

--- a/03.firmware/04.integratedAPP/components/mjpeg_player/include/mjpeg_player.h
+++ b/03.firmware/04.integratedAPP/components/mjpeg_player/include/mjpeg_player.h
@@ -53,18 +53,6 @@ typedef enum {
 } mjpeg_player_state_t;
 
 /**
- * @brief Initialize the shared JPEG decoder at startup
- *
- * This should be called EARLY in system initialization (before display init),
- * when internal DMA memory is still available.
- *
- * @return
- *     - ESP_OK: Success
- *     - ESP_ERR_NO_MEM: Not enough internal DMA memory
- */
-esp_err_t mjpeg_player_init_shared_decoder(void);
-
-/**
  * @brief Create MJPEG player instance
  *
  * @param config Player configuration

--- a/03.firmware/04.integratedAPP/components/mjpeg_player/src/mjpeg_player.c
+++ b/03.firmware/04.integratedAPP/components/mjpeg_player/src/mjpeg_player.c
@@ -6,6 +6,7 @@
  */
 
 #include "mjpeg_player.h"
+#include "shared_jpeg_decoder.h"
 #include "esp_log.h"
 #include "esp_heap_caps.h"
 #include "driver/jpeg_decode.h"
@@ -31,136 +32,6 @@ static const char *TAG = "MJPEG_PLAYER";
 /** Task configuration */
 #define MJPEG_TASK_STACK_SIZE  8192
 #define MJPEG_TASK_PRIORITY    7  // Higher priority for smoother playback
-
-// ============================================================================
-// Shared JPEG Decoder (Singleton)
-// ============================================================================
-// ESP32-P4 hardware JPEG decoder requires internal DMA memory for rxlink.
-// To avoid running out of internal memory, we share a single decoder instance.
-
-static jpeg_decoder_handle_t s_shared_jpeg_decoder = NULL;
-static SemaphoreHandle_t s_decoder_mutex = NULL;
-static int s_decoder_ref_count = 0;
-
-esp_err_t mjpeg_player_init_shared_decoder(void)
-{
-    if (s_decoder_mutex == NULL) {
-        s_decoder_mutex = xSemaphoreCreateMutex();
-        if (s_decoder_mutex == NULL) {
-            ESP_LOGE(TAG, "Failed to create decoder mutex");
-            return ESP_ERR_NO_MEM;
-        }
-    }
-
-    if (s_shared_jpeg_decoder != NULL) {
-        ESP_LOGD(TAG, "Shared JPEG decoder already initialized");
-        return ESP_OK;
-    }
-
-    // Log available internal DMA memory before allocation
-    size_t free_dma = heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
-    ESP_LOGD(TAG, "Free internal DMA memory before JPEG init: %u bytes", free_dma);
-
-    jpeg_decode_engine_cfg_t decode_eng_cfg = {
-        .timeout_ms = 100,
-    };
-    esp_err_t ret = jpeg_new_decoder_engine(&decode_eng_cfg, &s_shared_jpeg_decoder);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to create shared JPEG decoder: %s", esp_err_to_name(ret));
-        ESP_LOGE(TAG, "Free internal DMA memory: %u bytes (may need more for rxlink)", free_dma);
-        return ret;
-    }
-
-    ESP_LOGD(TAG, "Shared JPEG decoder created successfully");
-    return ESP_OK;
-}
-
-/**
- * @brief Get or create the shared JPEG decoder instance
- * @return ESP_OK on success
- */
-static esp_err_t get_shared_decoder(jpeg_decoder_handle_t *decoder)
-{
-    if (s_decoder_mutex == NULL) {
-        s_decoder_mutex = xSemaphoreCreateMutex();
-        if (s_decoder_mutex == NULL) {
-            return ESP_ERR_NO_MEM;
-        }
-    }
-
-    if (xSemaphoreTake(s_decoder_mutex, pdMS_TO_TICKS(1000)) != pdTRUE) {
-        return ESP_ERR_TIMEOUT;
-    }
-
-    esp_err_t ret = ESP_OK;
-
-    if (s_shared_jpeg_decoder == NULL) {
-        // Try to create the decoder (should have been initialized early)
-        ESP_LOGW(TAG, "Shared JPEG decoder not pre-initialized, creating now");
-
-        size_t free_dma = heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
-        ESP_LOGW(TAG, "Free internal DMA memory: %u bytes", free_dma);
-
-        jpeg_decode_engine_cfg_t decode_eng_cfg = {
-            .timeout_ms = 100,
-        };
-        ret = jpeg_new_decoder_engine(&decode_eng_cfg, &s_shared_jpeg_decoder);
-        if (ret != ESP_OK) {
-            ESP_LOGE(TAG, "Failed to create shared JPEG decoder: %s", esp_err_to_name(ret));
-            xSemaphoreGive(s_decoder_mutex);
-            return ret;
-        }
-        ESP_LOGD(TAG, "Shared JPEG decoder created (late init)");
-    }
-
-    s_decoder_ref_count++;
-    *decoder = s_shared_jpeg_decoder;
-
-    xSemaphoreGive(s_decoder_mutex);
-    return ESP_OK;
-}
-
-/**
- * @brief Release reference to shared JPEG decoder
- */
-static void release_shared_decoder(void)
-{
-    if (s_decoder_mutex == NULL) {
-        return;
-    }
-
-    if (xSemaphoreTake(s_decoder_mutex, pdMS_TO_TICKS(1000)) != pdTRUE) {
-        return;
-    }
-
-    s_decoder_ref_count--;
-
-    // Don't delete the decoder even when ref_count reaches 0
-    // Keep it alive to avoid re-allocation issues
-
-    xSemaphoreGive(s_decoder_mutex);
-}
-
-/**
- * @brief Lock shared decoder for exclusive use during decode operation
- */
-static bool lock_shared_decoder(uint32_t timeout_ms)
-{
-    if (s_decoder_mutex == NULL) {
-        return false;
-    }
-    return xSemaphoreTake(s_decoder_mutex, pdMS_TO_TICKS(timeout_ms)) == pdTRUE;
-}
-
-/**
- * @brief Unlock shared decoder
- */
-static void unlock_shared_decoder(void)
-{
-    if (s_decoder_mutex != NULL) {
-        xSemaphoreGive(s_decoder_mutex);
-    }
-}
 
 /** Frame index entry for seeking */
 typedef struct {
@@ -189,26 +60,21 @@ struct mjpeg_player {
     TaskHandle_t playback_task; /**< Playback task handle */
     volatile bool task_running; /**< Task running flag */
 
-    // Hardware JPEG decoder (reference to shared decoder)
-    jpeg_decoder_handle_t jpeg_decoder; /**< Reference to shared JPEG decoder */
-
     // Input buffer (JPEG data)
     uint8_t *jpeg_buffer;       /**< JPEG input buffer (DMA capable) */
     size_t jpeg_buffer_size;    /**< JPEG buffer allocated size */
 
-    // Output buffer (decoded RGB)
-    uint8_t *rgb_buffer;        /**< RGB output buffer (DMA capable) */
-    size_t rgb_buffer_size;     /**< RGB buffer allocated size */
-
-    lv_image_dsc_t image_dsc;   /**< LVGL image descriptor */
+    // Double buffering for RGB output
+    uint8_t *rgb_buffers[2];    /**< Two RGB output buffers for double buffering */
+    size_t rgb_buffer_size;     /**< Size of each RGB buffer */
+    lv_image_dsc_t image_dscs[2]; /**< LVGL image descriptors for each buffer */
+    volatile uint8_t back_idx;  /**< Index of back buffer (0 or 1) */
 
     mjpeg_frame_index_t *frame_index; /**< Frame index array */
     uint32_t frame_count;       /**< Total number of frames */
     uint32_t current_frame;     /**< Current frame index */
 
     SemaphoreHandle_t mutex;    /**< Thread safety mutex */
-
-    bool owns_decoder;          /**< True if this player owns a decoder reference */
 };
 
 // ============================================================================
@@ -326,7 +192,15 @@ static esp_err_t index_frames_fast(struct mjpeg_player *player)
 }
 
 /**
- * @brief Decode and display a frame using hardware JPEG decoder
+ * @brief Decode and display a frame using hardware JPEG decoder with double buffering
+ *
+ * Double buffering flow:
+ * 1. Decode JPEG to back buffer (no display lock needed)
+ * 2. Acquire display lock briefly
+ * 3. Swap front/back buffers (pointer switch only)
+ * 4. Release display lock
+ *
+ * This minimizes display lock hold time to reduce frame skipping.
  */
 static esp_err_t decode_and_display_frame(struct mjpeg_player *player, uint32_t frame_idx)
 {
@@ -343,7 +217,12 @@ static esp_err_t decode_and_display_frame(struct mjpeg_player *player, uint32_t 
         return ESP_ERR_NO_MEM;
     }
 
-    // Read JPEG frame data
+    // Get current back buffer index (decode target)
+    uint8_t back = player->back_idx;
+    uint8_t *decode_buffer = player->rgb_buffers[back];
+    lv_image_dsc_t *decode_dsc = &player->image_dscs[back];
+
+    // Read JPEG frame data (no lock needed)
     fseek(player->file, frame->offset, SEEK_SET);
     size_t bytes_read = fread(player->jpeg_buffer, 1, frame->size, player->file);
     if (bytes_read != frame->size) {
@@ -375,47 +254,49 @@ static esp_err_t decode_and_display_frame(struct mjpeg_player *player, uint32_t 
     }
 
     // Decode JPEG to RGB565 using hardware decoder (matches display format)
+    // Decoding to back buffer - no display lock needed here
     jpeg_decode_cfg_t decode_cfg = {
         .output_format = JPEG_DECODE_OUT_FORMAT_RGB565,
         .rgb_order = JPEG_DEC_RGB_ELEMENT_ORDER_BGR,  // Display expects BGR order
     };
 
     // Lock shared decoder for exclusive access during decode
-    if (!lock_shared_decoder(100)) {
+    if (!shared_jpeg_decoder_lock(100)) {
         ESP_LOGW(TAG, "Decoder busy, skipping frame %lu", (unsigned long)frame_idx);
         return ESP_ERR_TIMEOUT;
     }
 
     uint32_t out_size = 0;
     ret = jpeg_decoder_process(
-        player->jpeg_decoder,
+        shared_jpeg_decoder_get_handle(),
         &decode_cfg,
         player->jpeg_buffer,
         frame->size,
-        player->rgb_buffer,
+        decode_buffer,  // Decode to back buffer
         player->rgb_buffer_size,
         &out_size
     );
 
-    unlock_shared_decoder();
+    shared_jpeg_decoder_unlock();
 
     if (ret != ESP_OK) {
         ESP_LOGE(TAG, "Hardware JPEG decode failed: %s", esp_err_to_name(ret));
         return ret;
     }
 
-    // Update LVGL image descriptor with decoded RGB565 data
-    player->image_dsc.header.cf = LV_COLOR_FORMAT_RGB565;
-    player->image_dsc.header.w = info.width;
-    player->image_dsc.header.h = info.height;
-    player->image_dsc.header.stride = info.width * 2;  // RGB565 = 2 bytes per pixel
-    player->image_dsc.data_size = out_size;
-    player->image_dsc.data = player->rgb_buffer;
+    // Update back buffer's LVGL image descriptor (no lock needed)
+    decode_dsc->header.cf = LV_COLOR_FORMAT_RGB565;
+    decode_dsc->header.w = info.width;
+    decode_dsc->header.h = info.height;
+    decode_dsc->header.stride = info.width * 2;  // RGB565 = 2 bytes per pixel
+    decode_dsc->data_size = out_size;
+    decode_dsc->data = decode_buffer;
 
-    // Update LVGL image (must be done with display lock)
+    // Brief display lock for buffer swap only
     if (bsp_display_lock(pdMS_TO_TICKS(50))) {
-        lv_image_set_src(player->target_image, &player->image_dsc);
+        lv_image_set_src(player->target_image, decode_dsc);
         lv_obj_invalidate(player->target_image);  // Force redraw
+        player->back_idx = 1 - back;  // Swap buffers (0->1 or 1->0)
         bsp_display_unlock();
     } else {
         ESP_LOGW(TAG, "Display lock timeout, skipping frame %lu", (unsigned long)frame_idx);
@@ -523,13 +404,12 @@ esp_err_t mjpeg_player_create(const mjpeg_player_config_t *config, mjpeg_player_
     player->cancel_check = config->cancel_check;
     player->cancel_user_data = config->cancel_user_data;
 
-    // Get reference to shared JPEG decoder (singleton pattern)
-    ret = get_shared_decoder(&player->jpeg_decoder);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to get shared JPEG decoder: %s", esp_err_to_name(ret));
+    // Verify shared JPEG decoder is initialized
+    if (!shared_jpeg_decoder_is_initialized()) {
+        ESP_LOGE(TAG, "Shared JPEG decoder not initialized - call shared_jpeg_decoder_init() first");
+        ret = ESP_ERR_INVALID_STATE;
         goto cleanup;
     }
-    player->owns_decoder = true;
 
     // Allocate DMA-capable JPEG input buffer
     jpeg_decode_memory_alloc_cfg_t tx_mem_cfg = {
@@ -542,7 +422,7 @@ esp_err_t mjpeg_player_create(const mjpeg_player_config_t *config, mjpeg_player_
         goto cleanup;
     }
 
-    // Allocate DMA-capable RGB output buffer (RGB565: 2 bytes per pixel)
+    // Allocate DMA-capable RGB output buffers (double buffering)
     // Use larger dimension to handle both landscape and portrait videos
     // Also align to 16-byte boundaries as required by hardware JPEG decoder
     size_t max_dim = (player->target_width > player->target_height) ? player->target_width : player->target_height;
@@ -551,14 +431,23 @@ esp_err_t mjpeg_player_create(const mjpeg_player_config_t *config, mjpeg_player_
     jpeg_decode_memory_alloc_cfg_t rx_mem_cfg = {
         .buffer_direction = JPEG_DEC_ALLOC_OUTPUT_BUFFER,
     };
-    player->rgb_buffer = (uint8_t *)jpeg_alloc_decoder_mem(rgb_size, &rx_mem_cfg, &player->rgb_buffer_size);
-    if (player->rgb_buffer == NULL) {
-        ESP_LOGE(TAG, "Failed to allocate RGB output buffer");
-        ret = ESP_ERR_NO_MEM;
-        goto cleanup;
-    }
 
-    ESP_LOGD(TAG, "Allocated buffers: JPEG=%lu, RGB=%lu",
+    // Allocate two RGB buffers for double buffering
+    for (int i = 0; i < 2; i++) {
+        size_t actual_size = 0;
+        player->rgb_buffers[i] = (uint8_t *)jpeg_alloc_decoder_mem(rgb_size, &rx_mem_cfg, &actual_size);
+        if (player->rgb_buffers[i] == NULL) {
+            ESP_LOGE(TAG, "Failed to allocate RGB output buffer %d", i);
+            ret = ESP_ERR_NO_MEM;
+            goto cleanup;
+        }
+        if (i == 0) {
+            player->rgb_buffer_size = actual_size;
+        }
+    }
+    player->back_idx = 0;  // Start with buffer 0 as back buffer
+
+    ESP_LOGD(TAG, "Allocated buffers: JPEG=%lu, RGB=%lux2 (double buffering)",
              (unsigned long)player->jpeg_buffer_size, (unsigned long)player->rgb_buffer_size);
 
     // Index frames (using fast buffered method)
@@ -594,11 +483,10 @@ esp_err_t mjpeg_player_create(const mjpeg_player_config_t *config, mjpeg_player_
 cleanup:
     // Free resources in reverse allocation order (NULL-safe)
     free(player->frame_index);
-    free(player->rgb_buffer);
-    free(player->jpeg_buffer);
-    if (player->owns_decoder) {
-        release_shared_decoder();
+    for (int i = 0; i < 2; i++) {
+        free(player->rgb_buffers[i]);
     }
+    free(player->jpeg_buffer);
     if (player->mutex != NULL) {
         vSemaphoreDelete(player->mutex);
     }
@@ -632,18 +520,15 @@ void mjpeg_player_destroy(mjpeg_player_handle_t handle)
         free(player->frame_index);
     }
 
-    if (player->rgb_buffer != NULL) {
-        free(player->rgb_buffer);
+    // Free both RGB buffers (double buffering)
+    for (int i = 0; i < 2; i++) {
+        if (player->rgb_buffers[i] != NULL) {
+            free(player->rgb_buffers[i]);
+        }
     }
 
     if (player->jpeg_buffer != NULL) {
         free(player->jpeg_buffer);
-    }
-
-    // Release reference to shared decoder (don't delete it)
-    if (player->owns_decoder) {
-        release_shared_decoder();
-        player->owns_decoder = false;
     }
 
     if (player->file != NULL) {

--- a/03.firmware/04.integratedAPP/components/ui/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/components/ui/CMakeLists.txt
@@ -9,6 +9,6 @@ file(GLOB_RECURSE UI_SOURCES
 idf_component_register(
     SRCS ${UI_SOURCES}
     INCLUDE_DIRS "." "screens" "fonts" "images" "components"
-    REQUIRES lvgl ble_hid sdcard esp_driver_jpeg mjpeg_player alarm
+    REQUIRES lvgl ble_hid sdcard esp_driver_jpeg mjpeg_player alarm common
     PRIV_REQUIRES bsp_jc4880p443c
 )

--- a/03.firmware/04.integratedAPP/components/ui/ui_background.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_background.c
@@ -10,6 +10,7 @@
 #include "ui.h"
 #include "sdcard.h"
 #include "mjpeg_player.h"
+#include "shared_jpeg_decoder.h"
 #include "bsp/jc4880p443c.h"
 #include "esp_log.h"
 #include "esp_heap_caps.h"
@@ -27,69 +28,6 @@ static const char *TAG = "UI_BG";
 
 // Max JPEG file size for hardware decoder (256KB)
 #define MAX_JPEG_FILE_SIZE (256 * 1024)
-
-// ============================================================================
-// Shared JPEG Decoder (Singleton)
-// ============================================================================
-// ESP32-P4 hardware JPEG decoder requires internal DMA memory for rxlink.
-// To avoid running out of internal memory, we share a single decoder instance.
-
-static jpeg_decoder_handle_t s_shared_jpeg_decoder = NULL;
-static SemaphoreHandle_t s_decoder_mutex = NULL;
-
-esp_err_t ui_bg_init_jpeg_decoder(void)
-{
-    if (s_decoder_mutex == NULL) {
-        s_decoder_mutex = xSemaphoreCreateMutex();
-        if (s_decoder_mutex == NULL) {
-            ESP_LOGE(TAG, "Failed to create decoder mutex");
-            return ESP_ERR_NO_MEM;
-        }
-    }
-
-    if (s_shared_jpeg_decoder != NULL) {
-        ESP_LOGD(TAG, "Shared JPEG decoder already initialized");
-        return ESP_OK;
-    }
-
-    // Log available internal DMA memory before allocation
-    size_t free_dma = heap_caps_get_free_size(MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
-    ESP_LOGI(TAG, "Free internal DMA memory before JPEG init: %u bytes", free_dma);
-
-    jpeg_decode_engine_cfg_t decode_eng_cfg = {
-        .timeout_ms = 100,
-    };
-    esp_err_t ret = jpeg_new_decoder_engine(&decode_eng_cfg, &s_shared_jpeg_decoder);
-    if (ret != ESP_OK) {
-        ESP_LOGE(TAG, "Failed to create shared JPEG decoder: %s", esp_err_to_name(ret));
-        ESP_LOGE(TAG, "Free internal DMA memory: %u bytes (may need more for rxlink)", free_dma);
-        return ret;
-    }
-
-    ESP_LOGI(TAG, "Hardware JPEG decoder initialized successfully");
-    return ESP_OK;
-}
-
-/**
- * @brief Lock shared decoder for exclusive use during decode operation
- */
-static bool lock_jpeg_decoder(uint32_t timeout_ms)
-{
-    if (s_decoder_mutex == NULL) {
-        return false;
-    }
-    return xSemaphoreTake(s_decoder_mutex, pdMS_TO_TICKS(timeout_ms)) == pdTRUE;
-}
-
-/**
- * @brief Unlock shared decoder
- */
-static void unlock_jpeg_decoder(void)
-{
-    if (s_decoder_mutex != NULL) {
-        xSemaphoreGive(s_decoder_mutex);
-    }
-}
 
 /**
  * @brief Check if file is a JPEG
@@ -131,8 +69,8 @@ static esp_err_t hw_jpeg_decode_file(const char *file_path, lv_image_dsc_t *imag
     *out_data = NULL;
     memset(image_dsc, 0, sizeof(*image_dsc));
 
-    if (s_shared_jpeg_decoder == NULL) {
-        ESP_LOGE(TAG, "JPEG decoder not initialized - call ui_bg_init_jpeg_decoder() first");
+    if (!shared_jpeg_decoder_is_initialized()) {
+        ESP_LOGE(TAG, "JPEG decoder not initialized - call shared_jpeg_decoder_init() first");
         return ESP_ERR_INVALID_STATE;
     }
 
@@ -213,7 +151,7 @@ static esp_err_t hw_jpeg_decode_file(const char *file_path, lv_image_dsc_t *imag
     };
 
     // Lock shared decoder for exclusive access
-    if (!lock_jpeg_decoder(1000)) {
+    if (!shared_jpeg_decoder_lock(1000)) {
         ESP_LOGE(TAG, "Failed to lock shared decoder");
         free(rgb_buffer);
         free(jpeg_buffer);
@@ -222,7 +160,7 @@ static esp_err_t hw_jpeg_decode_file(const char *file_path, lv_image_dsc_t *imag
 
     uint32_t out_size = 0;
     ret = jpeg_decoder_process(
-        s_shared_jpeg_decoder,
+        shared_jpeg_decoder_get_handle(),
         &decode_cfg,
         jpeg_buffer,
         file_size,
@@ -231,7 +169,7 @@ static esp_err_t hw_jpeg_decode_file(const char *file_path, lv_image_dsc_t *imag
         &out_size
     );
 
-    unlock_jpeg_decoder();
+    shared_jpeg_decoder_unlock();
 
     // Free input buffer
     free(jpeg_buffer);

--- a/03.firmware/04.integratedAPP/components/ui/ui_background.h
+++ b/03.firmware/04.integratedAPP/components/ui/ui_background.h
@@ -16,19 +16,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Initialize the shared hardware JPEG decoder
- *
- * This should be called EARLY in system initialization (before display init),
- * when internal DMA memory is still available. The hardware JPEG decoder
- * requires internal DMA-capable memory for its descriptor chains.
- *
- * @return
- *     - ESP_OK: Success
- *     - ESP_ERR_NO_MEM: Not enough internal DMA memory
- */
-esp_err_t ui_bg_init_jpeg_decoder(void);
-
-/**
  * @brief Apply background image to all touchpad panels
  *
  * Sets the same background image on JPKeyboard, AtoZ, and Cursor

--- a/03.firmware/04.integratedAPP/dependencies.lock
+++ b/03.firmware/04.integratedAPP/dependencies.lock
@@ -75,7 +75,7 @@ dependencies:
     version: 1.2.0
   espressif/esp_hosted:
     component_hash: 
-      3790b0caf075d5119bdb98ee299a786c5ef43fc8a1d8da545c8731d7030035ec
+      49424510d8cf3659aa4bcf787e7b4abbf11848a25e7e5f133cf7f3324860d066
     dependencies:
     - name: idf
       require: private
@@ -83,7 +83,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com/
       type: service
-    version: 2.9.6
+    version: 2.11.3
   espressif/esp_lcd_touch:
     component_hash: 
       3f85a7d95af876f1a6ecca8eb90a81614890d0f03a038390804e5a77e2caf862
@@ -188,6 +188,23 @@ dependencies:
     - esp32p4
     - esp32h4
     version: 0.19.0~2
+  espressif/usb:
+    component_hash: 
+      f583375dac409f4287f3be9c188e54200b01a5ae774194b3bfee7d67e4e269d0
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.4'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    targets:
+    - esp32s2
+    - esp32s3
+    - esp32p4
+    - esp32h4
+    - linux
+    version: 1.1.0
   espressif/wifi_remote_over_eppp:
     component_hash: 
       e1b4c485ed5afe36615b9b555dfdcbe4be33898dc3732b5bedf235bba45bd286
@@ -220,6 +237,7 @@ direct_dependencies:
 - espressif/esp_hosted
 - espressif/esp_tinyusb
 - espressif/esp_wifi_remote
-manifest_hash: f3d1da510af1cd0a73c92c73211b6e9af0dabdd0b7f24d651092ff3e67409711
+- espressif/usb
+manifest_hash: d3a175746dfb33a2a9d2eca385e8b8efe69229028081bccde9a837bd9faad836
 target: esp32p4
 version: 2.0.0

--- a/03.firmware/04.integratedAPP/main/idf_component.yml
+++ b/03.firmware/04.integratedAPP/main/idf_component.yml
@@ -3,12 +3,12 @@
 
 dependencies:
   # USB HID support
-  espressif/esp_tinyusb: "^1.4.0"
+  espressif/esp_tinyusb: ^1.4.0
 
   # WiFi/BLE support (ESP32-C6 via ESP-Hosted)
   # Note: v2.9.6+ required for SD card coexistence fix
-  espressif/esp_wifi_remote: "*"
-  espressif/esp_hosted: "^2.9.6"
+  espressif/esp_wifi_remote: '*'
+  espressif/esp_hosted: ^2.9.6
 
   # Board Support Package (includes LVGL, Display, Touch, Audio)
   bsp_jc4880p443c:
@@ -16,3 +16,4 @@ dependencies:
 
   # LED strip support (for RGB LEDs if used) - DISABLED until needed
   # espressif/led_strip: "^2.5.0"
+  espressif/usb: '*'

--- a/03.firmware/04.integratedAPP/main/main.c
+++ b/03.firmware/04.integratedAPP/main/main.c
@@ -43,6 +43,7 @@
 // SD Card and Background management
 #include "sdcard.h"
 #include "ui_background.h"
+#include "shared_jpeg_decoder.h"
 
 // Alarm
 #include "alarm.h"
@@ -185,12 +186,12 @@ void app_main(void)
     ESP_LOGI(TAG, "ESP32-P4 initialized");
     ESP_LOGI(TAG, "Free heap: %lu bytes", esp_get_free_heap_size());
 
-    // Initialize hardware JPEG decoder early (requires internal DMA memory)
+    // Initialize shared hardware JPEG decoder early (requires internal DMA memory)
     // Must be done before display init consumes internal memory
-    ESP_LOGI(TAG, "Initializing hardware JPEG decoder...");
-    esp_err_t jpeg_ret = ui_bg_init_jpeg_decoder();
+    ESP_LOGI(TAG, "Initializing shared hardware JPEG decoder...");
+    esp_err_t jpeg_ret = shared_jpeg_decoder_init();
     if (jpeg_ret != ESP_OK) {
-        ESP_LOGW(TAG, "Hardware JPEG decoder init failed: %s (will use software decoder)",
+        ESP_LOGW(TAG, "Shared JPEG decoder init failed: %s (will use software decoder)",
                  esp_err_to_name(jpeg_ret));
     }
 


### PR DESCRIPTION
## Summary
- Shared JPEG decoder module created in common component
- Refactored ui_background and mjpeg_player to use shared decoder
- Added double buffering to mjpeg_player for reduced lock contention

## Changes
| File | Description |
|------|-------------|
| `components/common/include/shared_jpeg_decoder.h` | New shared decoder API |
| `components/common/src/shared_jpeg_decoder.c` | Shared decoder implementation |
| `components/mjpeg_player/src/mjpeg_player.c` | Double buffering + shared decoder |
| `components/ui/ui_background.c` | Shared decoder integration |
| `main/main.c` | Init shared decoder at startup |

## Test plan
- [x] Build passes
- [x] Static JPEG background loads correctly
- [x] MJPEG video plays (with known frame skipping issue)

## Known Issues
Frame skipping still occurs due to LVGL lock contention. See #16 for optimization work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)