### PR TITLE
feat: add WiFi, NTP, and Wake-on-LAN functionality (Issue #8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 **/build/
 **/sdkconfig
 **/sdkconfig.old
+**/sdkconfig.local
 
 # Claude Code session data
 .claude/logs/

--- a/03.firmware/04.integratedAPP/components/network/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/components/network/CMakeLists.txt
@@ -1,0 +1,8 @@
+# Network Component - WiFi, NTP, WOL
+
+idf_component_register(
+    SRCS "src/network.c" "src/ntp.c" "src/wol.c"
+    INCLUDE_DIRS "include"
+    REQUIRES freertos esp_common esp_wifi esp_netif lwip nvs_flash log drivers
+    PRIV_REQUIRES esp_hosted
+)

--- a/03.firmware/04.integratedAPP/components/network/include/network.h
+++ b/03.firmware/04.integratedAPP/components/network/include/network.h
@@ -1,0 +1,129 @@
+/**
+ * @file network.h
+ * @brief WiFi network connection management via ESP-Hosted
+ *
+ * Provides WiFi STA connection functionality using the ESP-Hosted
+ * coprocessor. Credentials are stored in NVS for persistence.
+ */
+
+#pragma once
+
+#include <stdbool.h>
+#include "esp_err.h"
+#include "esp_netif.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Network connection state
+ */
+typedef enum {
+    NETWORK_STATE_DISCONNECTED = 0,
+    NETWORK_STATE_CONNECTING,
+    NETWORK_STATE_CONNECTED,
+    NETWORK_STATE_ERROR,
+} network_state_t;
+
+/**
+ * @brief Network event callback type
+ */
+typedef void (*network_event_cb_t)(network_state_t state);
+
+/**
+ * @brief Initialize network subsystem
+ *
+ * Initializes WiFi STA mode via ESP-Hosted. Does not connect automatically.
+ * Call network_connect() after initialization to establish connection.
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t network_init(void);
+
+/**
+ * @brief Deinitialize network subsystem
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t network_deinit(void);
+
+/**
+ * @brief Connect to WiFi access point
+ *
+ * @param[in] ssid WiFi SSID (max 32 chars)
+ * @param[in] password WiFi password (max 64 chars)
+ * @return ESP_OK if connection started, ESP_FAIL otherwise
+ */
+esp_err_t network_connect(const char *ssid, const char *password);
+
+/**
+ * @brief Connect using saved credentials from NVS
+ *
+ * @return ESP_OK if connection started, ESP_ERR_NOT_FOUND if no saved credentials
+ */
+esp_err_t network_connect_saved(void);
+
+/**
+ * @brief Disconnect from WiFi
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t network_disconnect(void);
+
+/**
+ * @brief Check if connected to WiFi
+ *
+ * @return true if connected
+ */
+bool network_is_connected(void);
+
+/**
+ * @brief Get current network state
+ *
+ * @return Current network state
+ */
+network_state_t network_get_state(void);
+
+/**
+ * @brief Get IP address as string
+ *
+ * @param[out] ip_str Buffer to store IP address string (min 16 bytes)
+ * @param[in] len Buffer length
+ * @return ESP_OK on success, ESP_ERR_INVALID_STATE if not connected
+ */
+esp_err_t network_get_ip(char *ip_str, size_t len);
+
+/**
+ * @brief Save WiFi credentials to NVS
+ *
+ * @param[in] ssid WiFi SSID
+ * @param[in] password WiFi password
+ * @return ESP_OK on success
+ */
+esp_err_t network_save_credentials(const char *ssid, const char *password);
+
+/**
+ * @brief Clear saved WiFi credentials from NVS
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t network_clear_credentials(void);
+
+/**
+ * @brief Check if credentials are saved in NVS
+ *
+ * @return true if credentials exist
+ */
+bool network_has_saved_credentials(void);
+
+/**
+ * @brief Register network event callback
+ *
+ * @param[in] cb Callback function
+ */
+void network_register_callback(network_event_cb_t cb);
+
+#ifdef __cplusplus
+}
+#endif

--- a/03.firmware/04.integratedAPP/components/network/include/ntp.h
+++ b/03.firmware/04.integratedAPP/components/network/include/ntp.h
@@ -1,0 +1,121 @@
+/**
+ * @file ntp.h
+ * @brief NTP time synchronization with RTC update
+ *
+ * Synchronizes time from NTP servers and updates both the ESP32
+ * internal RTC and the external DS3231M RTC chip.
+ */
+
+#pragma once
+
+#include <time.h>
+#include <stdbool.h>
+#include "esp_err.h"
+#include "ds3231m.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief NTP server selection
+ */
+typedef enum {
+    NTP_SERVER_NICT = 0,    ///< NICT Japan (ntp.nict.jp)
+    NTP_SERVER_GOOGLE,      ///< Google (time.google.com)
+    NTP_SERVER_MAX
+} ntp_server_t;
+
+/**
+ * @brief NTP sync status
+ */
+typedef enum {
+    NTP_STATUS_IDLE = 0,
+    NTP_STATUS_SYNCING,
+    NTP_STATUS_SYNCED,
+    NTP_STATUS_FAILED,
+} ntp_status_t;
+
+/**
+ * @brief NTP sync callback type
+ */
+typedef void (*ntp_sync_cb_t)(ntp_status_t status);
+
+/**
+ * @brief Initialize NTP subsystem
+ *
+ * @param[in] rtc_handle DS3231M RTC handle for time writeback (can be NULL)
+ * @return ESP_OK on success
+ */
+esp_err_t ntp_init(ds3231m_handle_t *rtc_handle);
+
+/**
+ * @brief Deinitialize NTP subsystem
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t ntp_deinit(void);
+
+/**
+ * @brief Start NTP synchronization
+ *
+ * Initiates time sync from the selected NTP server. On success,
+ * updates both ESP32 internal RTC and DS3231M external RTC.
+ *
+ * @param[in] server NTP server to use
+ * @return ESP_OK if sync started, ESP_ERR_INVALID_STATE if not connected
+ */
+esp_err_t ntp_sync(ntp_server_t server);
+
+/**
+ * @brief Get current NTP sync status
+ *
+ * @return Current sync status
+ */
+ntp_status_t ntp_get_status(void);
+
+/**
+ * @brief Set time manually
+ *
+ * Updates both ESP32 internal RTC and DS3231M external RTC.
+ *
+ * @param[in] time Time to set
+ * @return ESP_OK on success
+ */
+esp_err_t ntp_set_time_manual(const struct tm *time);
+
+/**
+ * @brief Set default NTP server
+ *
+ * Saves preference to NVS.
+ *
+ * @param[in] server NTP server to set as default
+ * @return ESP_OK on success
+ */
+esp_err_t ntp_set_default_server(ntp_server_t server);
+
+/**
+ * @brief Get default NTP server
+ *
+ * @return Saved default server
+ */
+ntp_server_t ntp_get_default_server(void);
+
+/**
+ * @brief Get server name string
+ *
+ * @param[in] server Server enum value
+ * @return Server hostname string
+ */
+const char *ntp_get_server_name(ntp_server_t server);
+
+/**
+ * @brief Register NTP sync callback
+ *
+ * @param[in] cb Callback function
+ */
+void ntp_register_callback(ntp_sync_cb_t cb);
+
+#ifdef __cplusplus
+}
+#endif

--- a/03.firmware/04.integratedAPP/components/network/include/wol.h
+++ b/03.firmware/04.integratedAPP/components/network/include/wol.h
@@ -1,0 +1,96 @@
+/**
+ * @file wol.h
+ * @brief Wake-on-LAN magic packet sender
+ *
+ * Sends WOL magic packets to wake up computers on the network.
+ * Magic packet format: 0xFF x 6 + Target MAC x 16
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief WOL send result
+ */
+typedef enum {
+    WOL_RESULT_OK = 0,
+    WOL_RESULT_NOT_CONNECTED,
+    WOL_RESULT_INVALID_MAC,
+    WOL_RESULT_SEND_FAILED,
+} wol_result_t;
+
+/**
+ * @brief Initialize WOL subsystem
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t wol_init(void);
+
+/**
+ * @brief Deinitialize WOL subsystem
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t wol_deinit(void);
+
+/**
+ * @brief Send WOL magic packet to specified MAC address
+ *
+ * @param[in] mac Target MAC address (6 bytes)
+ * @return WOL_RESULT_OK on success
+ */
+wol_result_t wol_send(const uint8_t mac[6]);
+
+/**
+ * @brief Send WOL magic packet to default target (from Kconfig)
+ *
+ * @return WOL_RESULT_OK on success
+ */
+wol_result_t wol_send_default(void);
+
+/**
+ * @brief Parse MAC address string to bytes
+ *
+ * Supports formats: "AA:BB:CC:DD:EE:FF" or "AA-BB-CC-DD-EE-FF"
+ *
+ * @param[in] mac_str MAC address string
+ * @param[out] mac_bytes Output buffer (6 bytes)
+ * @return ESP_OK on success, ESP_ERR_INVALID_ARG on parse error
+ */
+esp_err_t wol_parse_mac(const char *mac_str, uint8_t mac_bytes[6]);
+
+/**
+ * @brief Get default target MAC address
+ *
+ * @param[out] mac_bytes Output buffer (6 bytes)
+ * @return ESP_OK on success
+ */
+esp_err_t wol_get_default_mac(uint8_t mac_bytes[6]);
+
+/**
+ * @brief Set default target MAC address (saved to NVS)
+ *
+ * @param[in] mac_bytes MAC address (6 bytes)
+ * @return ESP_OK on success
+ */
+esp_err_t wol_set_default_mac(const uint8_t mac_bytes[6]);
+
+/**
+ * @brief Get default MAC as string
+ *
+ * @param[out] mac_str Output buffer (min 18 bytes)
+ * @param[in] len Buffer length
+ * @return ESP_OK on success
+ */
+esp_err_t wol_get_default_mac_str(char *mac_str, size_t len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/03.firmware/04.integratedAPP/components/network/src/network.c
+++ b/03.firmware/04.integratedAPP/components/network/src/network.c
@@ -1,0 +1,417 @@
+/**
+ * @file network.c
+ * @brief WiFi network connection management via ESP-Hosted
+ */
+
+#include "network.h"
+#include "esp_log.h"
+#include "esp_wifi.h"
+#include "esp_event.h"
+#include "esp_netif.h"
+#include "esp_hosted.h"
+#include "nvs_flash.h"
+#include "nvs.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/event_groups.h"
+#include <string.h>
+
+static const char *TAG = "NETWORK";
+
+// NVS namespace and keys
+#define NVS_NAMESPACE "network"
+#define NVS_KEY_SSID "wifi_ssid"
+#define NVS_KEY_PASSWORD "wifi_pass"
+
+// Event group bits
+#define WIFI_CONNECTED_BIT   BIT0
+#define WIFI_FAIL_BIT        BIT1
+
+// State
+static bool g_initialized = false;
+static bool g_connect_requested = false;  // Track if connect was explicitly requested
+static network_state_t g_state = NETWORK_STATE_DISCONNECTED;
+static EventGroupHandle_t g_wifi_event_group = NULL;
+static esp_netif_t *g_sta_netif = NULL;
+static network_event_cb_t g_event_callback = NULL;
+static int g_retry_count = 0;
+static const int MAX_RETRY = 5;
+
+// Current connection info
+static char g_current_ssid[33] = {0};
+static esp_netif_ip_info_t g_ip_info;
+
+/**
+ * @brief WiFi event handler
+ */
+static void wifi_event_handler(void *arg, esp_event_base_t event_base,
+                               int32_t event_id, void *event_data)
+{
+    if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_START) {
+        ESP_LOGI(TAG, "WiFi STA started");
+        // Only connect if explicitly requested (via network_connect)
+        // Don't auto-connect here as credentials may not be configured yet
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
+        wifi_event_sta_disconnected_t *event = (wifi_event_sta_disconnected_t *)event_data;
+        ESP_LOGW(TAG, "WiFi disconnected, reason: %d", event->reason);
+
+        // Only retry if connection was explicitly requested
+        if (g_connect_requested && g_retry_count < MAX_RETRY) {
+            g_retry_count++;
+            ESP_LOGI(TAG, "Retrying connection (%d/%d)...", g_retry_count, MAX_RETRY);
+            esp_wifi_connect();
+            g_state = NETWORK_STATE_CONNECTING;
+        } else if (g_connect_requested) {
+            ESP_LOGE(TAG, "Connection failed after %d retries", MAX_RETRY);
+            xEventGroupSetBits(g_wifi_event_group, WIFI_FAIL_BIT);
+            g_state = NETWORK_STATE_ERROR;
+            g_connect_requested = false;
+        } else {
+            g_state = NETWORK_STATE_DISCONNECTED;
+        }
+
+        if (g_event_callback) {
+            g_event_callback(g_state);
+        }
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_CONNECTED) {
+        wifi_event_sta_connected_t *event = (wifi_event_sta_connected_t *)event_data;
+        ESP_LOGI(TAG, "Connected to AP: %s", event->ssid);
+        g_retry_count = 0;
+        // Wait for IP before setting CONNECTED state
+    }
+}
+
+/**
+ * @brief IP event handler
+ */
+static void ip_event_handler(void *arg, esp_event_base_t event_base,
+                             int32_t event_id, void *event_data)
+{
+    if (event_base == IP_EVENT && event_id == IP_EVENT_STA_GOT_IP) {
+        ip_event_got_ip_t *event = (ip_event_got_ip_t *)event_data;
+        memcpy(&g_ip_info, &event->ip_info, sizeof(esp_netif_ip_info_t));
+
+        ESP_LOGI(TAG, "Got IP: " IPSTR, IP2STR(&event->ip_info.ip));
+        g_state = NETWORK_STATE_CONNECTED;
+        xEventGroupSetBits(g_wifi_event_group, WIFI_CONNECTED_BIT);
+
+        if (g_event_callback) {
+            g_event_callback(g_state);
+        }
+    } else if (event_base == IP_EVENT && event_id == IP_EVENT_STA_LOST_IP) {
+        ESP_LOGW(TAG, "Lost IP address");
+        memset(&g_ip_info, 0, sizeof(g_ip_info));
+    }
+}
+
+esp_err_t network_init(void)
+{
+    if (g_initialized) {
+        return ESP_OK;
+    }
+
+    ESP_LOGI(TAG, "Initializing network subsystem...");
+
+    // Verify ESP-Hosted coprocessor is connected
+    // (BLE HID init should have already established this connection)
+    esp_hosted_coprocessor_fwver_t fwver;
+    if (esp_hosted_get_coprocessor_fwversion(&fwver) == ESP_OK) {
+        ESP_LOGI(TAG, "ESP-Hosted coprocessor FW: %lu.%lu.%lu",
+                 fwver.major1, fwver.minor1, fwver.patch1);
+    } else {
+        ESP_LOGW(TAG, "Could not get ESP-Hosted coprocessor version - WiFi may not work");
+    }
+
+    // Create event group
+    g_wifi_event_group = xEventGroupCreate();
+    if (!g_wifi_event_group) {
+        ESP_LOGE(TAG, "Failed to create event group");
+        return ESP_ERR_NO_MEM;
+    }
+
+    // Initialize TCP/IP stack
+    ESP_ERROR_CHECK(esp_netif_init());
+
+    // Create default event loop (may already exist from other components)
+    esp_err_t ret = esp_event_loop_create_default();
+    if (ret != ESP_OK && ret != ESP_ERR_INVALID_STATE) {
+        ESP_LOGE(TAG, "Failed to create event loop: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    // Create default WiFi STA netif
+    g_sta_netif = esp_netif_create_default_wifi_sta();
+    if (!g_sta_netif) {
+        ESP_LOGE(TAG, "Failed to create WiFi STA netif");
+        return ESP_FAIL;
+    }
+
+    // Initialize WiFi with default config
+    // Note: When using ESP-Hosted, esp_wifi APIs are remapped to esp_wifi_remote
+    // which communicates with the ESP32-C6 coprocessor
+    ESP_LOGI(TAG, "Initializing WiFi (via ESP-Hosted)...");
+    wifi_init_config_t cfg = WIFI_INIT_CONFIG_DEFAULT();
+    ret = esp_wifi_init(&cfg);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "WiFi init failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "WiFi init successful");
+
+    // Register event handlers
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(
+        WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler, NULL, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(
+        IP_EVENT, IP_EVENT_STA_GOT_IP, &ip_event_handler, NULL, NULL));
+    ESP_ERROR_CHECK(esp_event_handler_instance_register(
+        IP_EVENT, IP_EVENT_STA_LOST_IP, &ip_event_handler, NULL, NULL));
+
+    // Set WiFi mode to STA
+    ESP_LOGI(TAG, "Setting WiFi mode to STA...");
+    ret = esp_wifi_set_mode(WIFI_MODE_STA);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "WiFi set mode failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    // Start WiFi
+    ESP_LOGI(TAG, "Starting WiFi...");
+    ret = esp_wifi_start();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "WiFi start failed: %s", esp_err_to_name(ret));
+        return ret;
+    }
+    ESP_LOGI(TAG, "WiFi started successfully");
+
+    g_initialized = true;
+    g_state = NETWORK_STATE_DISCONNECTED;
+    ESP_LOGI(TAG, "Network subsystem initialized");
+
+    return ESP_OK;
+}
+
+esp_err_t network_deinit(void)
+{
+    if (!g_initialized) {
+        return ESP_OK;
+    }
+
+    esp_wifi_stop();
+    esp_wifi_deinit();
+
+    if (g_sta_netif) {
+        esp_netif_destroy(g_sta_netif);
+        g_sta_netif = NULL;
+    }
+
+    if (g_wifi_event_group) {
+        vEventGroupDelete(g_wifi_event_group);
+        g_wifi_event_group = NULL;
+    }
+
+    g_initialized = false;
+    g_state = NETWORK_STATE_DISCONNECTED;
+    ESP_LOGI(TAG, "Network subsystem deinitialized");
+
+    return ESP_OK;
+}
+
+esp_err_t network_connect(const char *ssid, const char *password)
+{
+    if (!g_initialized) {
+        ESP_LOGE(TAG, "Network not initialized");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (!ssid || strlen(ssid) == 0) {
+        ESP_LOGE(TAG, "Invalid SSID");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    ESP_LOGI(TAG, "Connecting to WiFi: %s", ssid);
+
+    // Store SSID for reference
+    strncpy(g_current_ssid, ssid, sizeof(g_current_ssid) - 1);
+    g_current_ssid[sizeof(g_current_ssid) - 1] = '\0';
+
+    // Configure WiFi
+    wifi_config_t wifi_config = {0};
+    strncpy((char *)wifi_config.sta.ssid, ssid, sizeof(wifi_config.sta.ssid) - 1);
+    if (password && strlen(password) > 0) {
+        strncpy((char *)wifi_config.sta.password, password,
+                sizeof(wifi_config.sta.password) - 1);
+    }
+    wifi_config.sta.threshold.authmode = password && strlen(password) > 0 ?
+                                         WIFI_AUTH_WPA2_PSK : WIFI_AUTH_OPEN;
+
+    ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
+
+    // Reset retry counter and mark connection as requested
+    g_retry_count = 0;
+    g_connect_requested = true;
+    g_state = NETWORK_STATE_CONNECTING;
+
+    // Clear event bits
+    xEventGroupClearBits(g_wifi_event_group, WIFI_CONNECTED_BIT | WIFI_FAIL_BIT);
+
+    // Start connection
+    ESP_LOGI(TAG, "Starting WiFi connection to: %s", ssid);
+    esp_err_t ret = esp_wifi_connect();
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "WiFi connect failed: %s", esp_err_to_name(ret));
+        g_state = NETWORK_STATE_ERROR;
+        g_connect_requested = false;
+        return ret;
+    }
+    ESP_LOGI(TAG, "WiFi connect initiated");
+
+    if (g_event_callback) {
+        g_event_callback(g_state);
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t network_connect_saved(void)
+{
+    char ssid[33] = {0};
+    char password[65] = {0};
+    nvs_handle_t nvs_handle;
+
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READONLY, &nvs_handle);
+    if (ret != ESP_OK) {
+        ESP_LOGW(TAG, "No saved credentials found");
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    size_t ssid_len = sizeof(ssid);
+    size_t pass_len = sizeof(password);
+
+    ret = nvs_get_str(nvs_handle, NVS_KEY_SSID, ssid, &ssid_len);
+    if (ret != ESP_OK) {
+        nvs_close(nvs_handle);
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    // Password is optional
+    nvs_get_str(nvs_handle, NVS_KEY_PASSWORD, password, &pass_len);
+    nvs_close(nvs_handle);
+
+    ESP_LOGI(TAG, "Connecting with saved credentials: %s", ssid);
+    return network_connect(ssid, password);
+}
+
+esp_err_t network_disconnect(void)
+{
+    if (!g_initialized) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    ESP_LOGI(TAG, "Disconnecting from WiFi");
+    g_connect_requested = false;  // Prevent auto-reconnect
+    g_retry_count = MAX_RETRY;
+    esp_wifi_disconnect();
+    g_state = NETWORK_STATE_DISCONNECTED;
+
+    if (g_event_callback) {
+        g_event_callback(g_state);
+    }
+
+    return ESP_OK;
+}
+
+bool network_is_connected(void)
+{
+    return g_state == NETWORK_STATE_CONNECTED;
+}
+
+network_state_t network_get_state(void)
+{
+    return g_state;
+}
+
+esp_err_t network_get_ip(char *ip_str, size_t len)
+{
+    if (!ip_str || len < 16) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    if (g_state != NETWORK_STATE_CONNECTED) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    snprintf(ip_str, len, IPSTR, IP2STR(&g_ip_info.ip));
+    return ESP_OK;
+}
+
+esp_err_t network_save_credentials(const char *ssid, const char *password)
+{
+    if (!ssid || strlen(ssid) == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    nvs_handle_t nvs_handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to open NVS: %s", esp_err_to_name(ret));
+        return ret;
+    }
+
+    ret = nvs_set_str(nvs_handle, NVS_KEY_SSID, ssid);
+    if (ret != ESP_OK) {
+        nvs_close(nvs_handle);
+        return ret;
+    }
+
+    if (password && strlen(password) > 0) {
+        ret = nvs_set_str(nvs_handle, NVS_KEY_PASSWORD, password);
+        if (ret != ESP_OK) {
+            nvs_close(nvs_handle);
+            return ret;
+        }
+    } else {
+        nvs_erase_key(nvs_handle, NVS_KEY_PASSWORD);
+    }
+
+    ret = nvs_commit(nvs_handle);
+    nvs_close(nvs_handle);
+
+    ESP_LOGI(TAG, "WiFi credentials saved for: %s", ssid);
+    return ret;
+}
+
+esp_err_t network_clear_credentials(void)
+{
+    nvs_handle_t nvs_handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+
+    nvs_erase_key(nvs_handle, NVS_KEY_SSID);
+    nvs_erase_key(nvs_handle, NVS_KEY_PASSWORD);
+    ret = nvs_commit(nvs_handle);
+    nvs_close(nvs_handle);
+
+    ESP_LOGI(TAG, "WiFi credentials cleared");
+    return ret;
+}
+
+bool network_has_saved_credentials(void)
+{
+    nvs_handle_t nvs_handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READONLY, &nvs_handle);
+    if (ret != ESP_OK) {
+        return false;
+    }
+
+    size_t len = 0;
+    ret = nvs_get_str(nvs_handle, NVS_KEY_SSID, NULL, &len);
+    nvs_close(nvs_handle);
+
+    return (ret == ESP_OK && len > 0);
+}
+
+void network_register_callback(network_event_cb_t cb)
+{
+    g_event_callback = cb;
+}

--- a/03.firmware/04.integratedAPP/components/network/src/ntp.c
+++ b/03.firmware/04.integratedAPP/components/network/src/ntp.c
@@ -1,0 +1,254 @@
+/**
+ * @file ntp.c
+ * @brief NTP time synchronization with RTC update
+ */
+
+#include "ntp.h"
+#include "network.h"
+#include "esp_log.h"
+#include "esp_sntp.h"
+#include "nvs_flash.h"
+#include "nvs.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include <string.h>
+#include <sys/time.h>
+
+static const char *TAG = "NTP";
+
+// NVS namespace and keys
+#define NVS_NAMESPACE "network"
+#define NVS_KEY_NTP_SERVER "ntp_server"
+
+// NTP server hostnames
+static const char *NTP_SERVERS[] = {
+    "ntp.nict.jp",      // NICT Japan
+    "time.google.com",  // Google
+};
+
+// Server display names
+static const char *NTP_SERVER_NAMES[] = {
+    "NICT (ntp.nict.jp)",
+    "Google (time.google.com)",
+};
+
+// State
+static bool g_initialized = false;
+static ntp_status_t g_status = NTP_STATUS_IDLE;
+static ds3231m_handle_t *g_rtc_handle = NULL;
+static ntp_sync_cb_t g_sync_callback = NULL;
+static ntp_server_t g_current_server = NTP_SERVER_NICT;
+
+/**
+ * @brief SNTP time sync notification callback
+ */
+static void ntp_sync_notification_cb(struct timeval *tv)
+{
+    ESP_LOGI(TAG, "NTP sync completed");
+
+    // Get synced time
+    time_t now = tv->tv_sec;
+    struct tm timeinfo;
+    localtime_r(&now, &timeinfo);
+
+    ESP_LOGI(TAG, "Synced time: %04d-%02d-%02d %02d:%02d:%02d",
+             timeinfo.tm_year + 1900, timeinfo.tm_mon + 1, timeinfo.tm_mday,
+             timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec);
+
+    // Update DS3231M external RTC
+    if (g_rtc_handle && g_rtc_handle->dev_handle) {
+        esp_err_t ret = ds3231m_set_time(g_rtc_handle, &timeinfo);
+        if (ret == ESP_OK) {
+            ESP_LOGI(TAG, "DS3231M RTC updated successfully");
+        } else {
+            ESP_LOGW(TAG, "Failed to update DS3231M: %s", esp_err_to_name(ret));
+        }
+    }
+
+    g_status = NTP_STATUS_SYNCED;
+
+    if (g_sync_callback) {
+        g_sync_callback(g_status);
+    }
+}
+
+esp_err_t ntp_init(ds3231m_handle_t *rtc_handle)
+{
+    if (g_initialized) {
+        return ESP_OK;
+    }
+
+    ESP_LOGI(TAG, "Initializing NTP subsystem...");
+
+    g_rtc_handle = rtc_handle;
+
+    // Load default server from NVS
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READONLY, &nvs_handle) == ESP_OK) {
+        uint8_t server;
+        if (nvs_get_u8(nvs_handle, NVS_KEY_NTP_SERVER, &server) == ESP_OK) {
+            if (server < NTP_SERVER_MAX) {
+                g_current_server = (ntp_server_t)server;
+            }
+        }
+        nvs_close(nvs_handle);
+    }
+
+    ESP_LOGI(TAG, "Default NTP server: %s", NTP_SERVER_NAMES[g_current_server]);
+
+    // Set timezone to JST (UTC+9)
+    setenv("TZ", "JST-9", 1);
+    tzset();
+
+    g_initialized = true;
+    ESP_LOGI(TAG, "NTP subsystem initialized");
+
+    return ESP_OK;
+}
+
+esp_err_t ntp_deinit(void)
+{
+    if (!g_initialized) {
+        return ESP_OK;
+    }
+
+    esp_sntp_stop();
+    g_initialized = false;
+    g_status = NTP_STATUS_IDLE;
+    ESP_LOGI(TAG, "NTP subsystem deinitialized");
+
+    return ESP_OK;
+}
+
+esp_err_t ntp_sync(ntp_server_t server)
+{
+    if (!g_initialized) {
+        ESP_LOGE(TAG, "NTP not initialized");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (!network_is_connected()) {
+        ESP_LOGE(TAG, "Network not connected");
+        g_status = NTP_STATUS_FAILED;
+        if (g_sync_callback) {
+            g_sync_callback(g_status);
+        }
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (server >= NTP_SERVER_MAX) {
+        server = NTP_SERVER_NICT;
+    }
+
+    ESP_LOGI(TAG, "Starting NTP sync with %s", NTP_SERVERS[server]);
+    g_status = NTP_STATUS_SYNCING;
+
+    if (g_sync_callback) {
+        g_sync_callback(g_status);
+    }
+
+    // Stop any existing SNTP operation
+    if (esp_sntp_enabled()) {
+        esp_sntp_stop();
+    }
+
+    // Configure SNTP
+    esp_sntp_setoperatingmode(SNTP_OPMODE_POLL);
+    esp_sntp_setservername(0, NTP_SERVERS[server]);
+    esp_sntp_set_time_sync_notification_cb(ntp_sync_notification_cb);
+
+    // Start SNTP (non-blocking)
+    // Sync completion will be notified via ntp_sync_notification_cb
+    esp_sntp_init();
+
+    ESP_LOGI(TAG, "NTP sync started (async)");
+    return ESP_OK;
+}
+
+ntp_status_t ntp_get_status(void)
+{
+    return g_status;
+}
+
+esp_err_t ntp_set_time_manual(const struct tm *time)
+{
+    if (!time) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    ESP_LOGI(TAG, "Setting time manually: %04d-%02d-%02d %02d:%02d:%02d",
+             time->tm_year + 1900, time->tm_mon + 1, time->tm_mday,
+             time->tm_hour, time->tm_min, time->tm_sec);
+
+    // Set ESP32 internal RTC
+    struct tm time_copy = *time;
+    time_t now = mktime(&time_copy);
+    struct timeval tv = {
+        .tv_sec = now,
+        .tv_usec = 0
+    };
+
+    if (settimeofday(&tv, NULL) != 0) {
+        ESP_LOGE(TAG, "Failed to set ESP32 internal RTC");
+        return ESP_FAIL;
+    }
+
+    ESP_LOGI(TAG, "ESP32 internal RTC updated");
+
+    // Set DS3231M external RTC
+    if (g_rtc_handle && g_rtc_handle->dev_handle) {
+        esp_err_t ret = ds3231m_set_time(g_rtc_handle, time);
+        if (ret == ESP_OK) {
+            ESP_LOGI(TAG, "DS3231M RTC updated successfully");
+        } else {
+            ESP_LOGW(TAG, "Failed to update DS3231M: %s", esp_err_to_name(ret));
+            return ret;
+        }
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t ntp_set_default_server(ntp_server_t server)
+{
+    if (server >= NTP_SERVER_MAX) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    nvs_handle_t nvs_handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+
+    ret = nvs_set_u8(nvs_handle, NVS_KEY_NTP_SERVER, (uint8_t)server);
+    if (ret == ESP_OK) {
+        ret = nvs_commit(nvs_handle);
+    }
+    nvs_close(nvs_handle);
+
+    if (ret == ESP_OK) {
+        g_current_server = server;
+        ESP_LOGI(TAG, "Default NTP server set to: %s", NTP_SERVER_NAMES[server]);
+    }
+
+    return ret;
+}
+
+ntp_server_t ntp_get_default_server(void)
+{
+    return g_current_server;
+}
+
+const char *ntp_get_server_name(ntp_server_t server)
+{
+    if (server >= NTP_SERVER_MAX) {
+        return "Unknown";
+    }
+    return NTP_SERVER_NAMES[server];
+}
+
+void ntp_register_callback(ntp_sync_cb_t cb)
+{
+    g_sync_callback = cb;
+}

--- a/03.firmware/04.integratedAPP/components/network/src/wol.c
+++ b/03.firmware/04.integratedAPP/components/network/src/wol.c
@@ -1,0 +1,268 @@
+/**
+ * @file wol.c
+ * @brief Wake-on-LAN magic packet sender
+ */
+
+#include "wol.h"
+#include "network.h"
+#include "esp_log.h"
+#include "nvs_flash.h"
+#include "nvs.h"
+#include "lwip/sockets.h"
+#include "lwip/netdb.h"
+#include <string.h>
+#include <stdio.h>
+
+static const char *TAG = "WOL";
+
+// NVS namespace and keys
+#define NVS_NAMESPACE "network"
+#define NVS_KEY_WOL_MAC "wol_mac"
+
+// WOL constants
+#define WOL_PORT 9
+#define WOL_MAGIC_HEADER_LEN 6
+#define WOL_MAC_REPEAT 16
+#define WOL_PACKET_LEN (WOL_MAGIC_HEADER_LEN + (6 * WOL_MAC_REPEAT))
+
+// State
+static bool g_initialized = false;
+static uint8_t g_default_mac[6] = {0};
+
+/**
+ * @brief Build WOL magic packet
+ */
+static void build_magic_packet(uint8_t *packet, const uint8_t mac[6])
+{
+    // Header: 6 bytes of 0xFF
+    memset(packet, 0xFF, WOL_MAGIC_HEADER_LEN);
+
+    // Repeat MAC address 16 times
+    for (int i = 0; i < WOL_MAC_REPEAT; i++) {
+        memcpy(packet + WOL_MAGIC_HEADER_LEN + (i * 6), mac, 6);
+    }
+}
+
+esp_err_t wol_init(void)
+{
+    if (g_initialized) {
+        return ESP_OK;
+    }
+
+    ESP_LOGI(TAG, "Initializing WOL subsystem...");
+
+    // Load default MAC from NVS
+    nvs_handle_t nvs_handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READONLY, &nvs_handle) == ESP_OK) {
+        size_t len = 6;
+        if (nvs_get_blob(nvs_handle, NVS_KEY_WOL_MAC, g_default_mac, &len) == ESP_OK) {
+            ESP_LOGI(TAG, "Loaded default MAC: %02X:%02X:%02X:%02X:%02X:%02X",
+                     g_default_mac[0], g_default_mac[1], g_default_mac[2],
+                     g_default_mac[3], g_default_mac[4], g_default_mac[5]);
+        }
+        nvs_close(nvs_handle);
+    }
+
+#ifdef CONFIG_HANDY_WOL_DEFAULT_MAC
+    // If no MAC saved and Kconfig has default, parse it
+    if (g_default_mac[0] == 0 && g_default_mac[1] == 0 && g_default_mac[2] == 0 &&
+        g_default_mac[3] == 0 && g_default_mac[4] == 0 && g_default_mac[5] == 0) {
+        if (wol_parse_mac(CONFIG_HANDY_WOL_DEFAULT_MAC, g_default_mac) == ESP_OK) {
+            ESP_LOGI(TAG, "Using Kconfig default MAC: %s", CONFIG_HANDY_WOL_DEFAULT_MAC);
+        }
+    }
+#endif
+
+    g_initialized = true;
+    ESP_LOGI(TAG, "WOL subsystem initialized");
+
+    return ESP_OK;
+}
+
+esp_err_t wol_deinit(void)
+{
+    if (!g_initialized) {
+        return ESP_OK;
+    }
+
+    g_initialized = false;
+    ESP_LOGI(TAG, "WOL subsystem deinitialized");
+
+    return ESP_OK;
+}
+
+wol_result_t wol_send(const uint8_t mac[6])
+{
+    if (!g_initialized) {
+        ESP_LOGE(TAG, "WOL not initialized");
+        return WOL_RESULT_SEND_FAILED;
+    }
+
+    if (!network_is_connected()) {
+        ESP_LOGE(TAG, "Network not connected");
+        return WOL_RESULT_NOT_CONNECTED;
+    }
+
+    // Validate MAC (at least one non-zero byte)
+    bool valid = false;
+    for (int i = 0; i < 6; i++) {
+        if (mac[i] != 0) {
+            valid = true;
+            break;
+        }
+    }
+    if (!valid) {
+        ESP_LOGE(TAG, "Invalid MAC address (all zeros)");
+        return WOL_RESULT_INVALID_MAC;
+    }
+
+    ESP_LOGI(TAG, "Sending WOL packet to %02X:%02X:%02X:%02X:%02X:%02X",
+             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+
+    // Build magic packet
+    uint8_t packet[WOL_PACKET_LEN];
+    build_magic_packet(packet, mac);
+
+    // Create UDP socket
+    int sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (sock < 0) {
+        ESP_LOGE(TAG, "Failed to create socket: %d", errno);
+        return WOL_RESULT_SEND_FAILED;
+    }
+
+    // Enable broadcast
+    int broadcast = 1;
+    if (setsockopt(sock, SOL_SOCKET, SO_BROADCAST, &broadcast, sizeof(broadcast)) < 0) {
+        ESP_LOGE(TAG, "Failed to set SO_BROADCAST: %d", errno);
+        close(sock);
+        return WOL_RESULT_SEND_FAILED;
+    }
+
+    // Setup destination address (broadcast)
+    struct sockaddr_in dest_addr;
+    memset(&dest_addr, 0, sizeof(dest_addr));
+    dest_addr.sin_family = AF_INET;
+    dest_addr.sin_port = htons(WOL_PORT);
+    dest_addr.sin_addr.s_addr = htonl(INADDR_BROADCAST);
+
+    // Send magic packet
+    int sent = sendto(sock, packet, WOL_PACKET_LEN, 0,
+                      (struct sockaddr *)&dest_addr, sizeof(dest_addr));
+
+    close(sock);
+
+    if (sent != WOL_PACKET_LEN) {
+        ESP_LOGE(TAG, "Failed to send packet: sent=%d, expected=%d", sent, WOL_PACKET_LEN);
+        return WOL_RESULT_SEND_FAILED;
+    }
+
+    ESP_LOGI(TAG, "WOL packet sent successfully (%d bytes)", sent);
+    return WOL_RESULT_OK;
+}
+
+wol_result_t wol_send_default(void)
+{
+    if (!g_initialized) {
+        return WOL_RESULT_SEND_FAILED;
+    }
+
+    // Check if default MAC is set
+    bool has_mac = false;
+    for (int i = 0; i < 6; i++) {
+        if (g_default_mac[i] != 0) {
+            has_mac = true;
+            break;
+        }
+    }
+
+    if (!has_mac) {
+        ESP_LOGE(TAG, "No default MAC address configured");
+        return WOL_RESULT_INVALID_MAC;
+    }
+
+    return wol_send(g_default_mac);
+}
+
+esp_err_t wol_parse_mac(const char *mac_str, uint8_t mac_bytes[6])
+{
+    if (!mac_str || !mac_bytes) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    unsigned int bytes[6];
+    int count;
+
+    // Try colon format first (AA:BB:CC:DD:EE:FF)
+    count = sscanf(mac_str, "%02x:%02x:%02x:%02x:%02x:%02x",
+                   &bytes[0], &bytes[1], &bytes[2],
+                   &bytes[3], &bytes[4], &bytes[5]);
+
+    if (count != 6) {
+        // Try dash format (AA-BB-CC-DD-EE-FF)
+        count = sscanf(mac_str, "%02x-%02x-%02x-%02x-%02x-%02x",
+                       &bytes[0], &bytes[1], &bytes[2],
+                       &bytes[3], &bytes[4], &bytes[5]);
+    }
+
+    if (count != 6) {
+        ESP_LOGE(TAG, "Invalid MAC format: %s", mac_str);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    for (int i = 0; i < 6; i++) {
+        mac_bytes[i] = (uint8_t)bytes[i];
+    }
+
+    return ESP_OK;
+}
+
+esp_err_t wol_get_default_mac(uint8_t mac_bytes[6])
+{
+    if (!mac_bytes) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    memcpy(mac_bytes, g_default_mac, 6);
+    return ESP_OK;
+}
+
+esp_err_t wol_set_default_mac(const uint8_t mac_bytes[6])
+{
+    if (!mac_bytes) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    nvs_handle_t nvs_handle;
+    esp_err_t ret = nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs_handle);
+    if (ret != ESP_OK) {
+        return ret;
+    }
+
+    ret = nvs_set_blob(nvs_handle, NVS_KEY_WOL_MAC, mac_bytes, 6);
+    if (ret == ESP_OK) {
+        ret = nvs_commit(nvs_handle);
+    }
+    nvs_close(nvs_handle);
+
+    if (ret == ESP_OK) {
+        memcpy(g_default_mac, mac_bytes, 6);
+        ESP_LOGI(TAG, "Default MAC set to: %02X:%02X:%02X:%02X:%02X:%02X",
+                 mac_bytes[0], mac_bytes[1], mac_bytes[2],
+                 mac_bytes[3], mac_bytes[4], mac_bytes[5]);
+    }
+
+    return ret;
+}
+
+esp_err_t wol_get_default_mac_str(char *mac_str, size_t len)
+{
+    if (!mac_str || len < 18) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    snprintf(mac_str, len, "%02X:%02X:%02X:%02X:%02X:%02X",
+             g_default_mac[0], g_default_mac[1], g_default_mac[2],
+             g_default_mac[3], g_default_mac[4], g_default_mac[5]);
+
+    return ESP_OK;
+}

--- a/03.firmware/04.integratedAPP/components/ui/CMakeLists.txt
+++ b/03.firmware/04.integratedAPP/components/ui/CMakeLists.txt
@@ -9,6 +9,6 @@ file(GLOB_RECURSE UI_SOURCES
 idf_component_register(
     SRCS ${UI_SOURCES}
     INCLUDE_DIRS "." "screens" "fonts" "images" "components"
-    REQUIRES lvgl ble_hid sdcard esp_driver_jpeg mjpeg_player alarm common
+    REQUIRES lvgl ble_hid sdcard esp_driver_jpeg mjpeg_player alarm common network
     PRIV_REQUIRES bsp_jc4880p443c
 )

--- a/03.firmware/04.integratedAPP/components/ui/ui_navigation.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_navigation.c
@@ -38,6 +38,9 @@
 #include "sdcard.h"
 #include "ui_background.h"
 
+// Network settings
+#include "ui_network.h"
+
 static const char *TAG = "UI_NAV";
 
 // ============================================================================
@@ -223,6 +226,7 @@ static volatile uint8_t g_alarm_triggered_index = 0xFF;
 static lv_obj_t *bg_touchpad_dropdown = NULL;
 static lv_obj_t *bg_clock_dropdown = NULL;
 static bool bg_ui_created = false;
+static bool network_ui_created = false;
 
 // Background file list storage
 #define MAX_BG_FILES 32
@@ -1500,6 +1504,7 @@ static void setup_settings_nav(void)
         bg_touchpad_dropdown = NULL;
         bg_clock_dropdown = NULL;
         bg_ui_created = false;
+        network_ui_created = false;
     }
 
     if (ui_SettingScreen && !setting_back_btn) {
@@ -1632,6 +1637,22 @@ static void setup_settings_nav(void)
         bg_ui_created = true;
     }
 
+    // Create Network settings UI (below Background settings)
+    if (ui_Panel43 && !network_ui_created) {
+        // Add separator
+        lv_obj_t *separator3 = lv_obj_create(ui_Panel43);
+        lv_obj_set_size(separator3, 200, 2);
+        lv_obj_set_style_bg_color(separator3, lv_color_hex(0x444444), 0);
+        lv_obj_set_style_border_width(separator3, 0, 0);
+        lv_obj_set_style_pad_all(separator3, 0, 0);
+
+        // Initialize network settings UI
+        ui_network_init(ui_Panel43);
+        network_ui_created = true;
+
+        ESP_LOGI(TAG, "Network settings UI created");
+    }
+
     last_settings_screen = ui_SettingScreen;
     ESP_LOGD(TAG, "Settings nav ready");
 }
@@ -1682,6 +1703,11 @@ static void nav_timer_cb(lv_timer_t *timer)
     // Check for alarm trigger and show popup (thread-safe via LVGL timer)
     if (g_alarm_triggered && !ui_alarm_is_popup_visible()) {
         ui_alarm_show_trigger_popup(g_alarm_triggered_index);
+    }
+
+    // Update network status UI (WiFi connection state)
+    if (network_ui_created) {
+        ui_network_update();
     }
 }
 

--- a/03.firmware/04.integratedAPP/components/ui/ui_network.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_network.c
@@ -1,0 +1,497 @@
+/**
+ * @file ui_network.c
+ * @brief Network Settings UI - WiFi, NTP, and WOL controls
+ */
+
+#include "ui_network.h"
+#include "network.h"
+#include "ntp.h"
+#include "wol.h"
+#include "esp_log.h"
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+static const char *TAG = "UI_NETWORK";
+
+// UI elements
+static lv_obj_t *s_network_panel = NULL;
+static lv_obj_t *s_wifi_status_label = NULL;
+static lv_obj_t *s_ntp_dropdown = NULL;
+static lv_obj_t *s_sync_btn = NULL;
+static lv_obj_t *s_sync_status_label = NULL;
+
+// Manual time inputs
+static lv_obj_t *s_year_dropdown = NULL;
+static lv_obj_t *s_month_dropdown = NULL;
+static lv_obj_t *s_day_dropdown = NULL;
+static lv_obj_t *s_hour_dropdown = NULL;
+static lv_obj_t *s_minute_dropdown = NULL;
+static lv_obj_t *s_manual_set_btn = NULL;
+
+// WOL elements
+static lv_obj_t *s_wol_target_label = NULL;
+static lv_obj_t *s_wol_btn = NULL;
+
+// Year options (2024-2035)
+static const char *YEAR_OPTIONS =
+    "2024\n2025\n2026\n2027\n2028\n2029\n2030\n2031\n2032\n2033\n2034\n2035";
+
+// Month options (01-12)
+static const char *MONTH_OPTIONS =
+    "01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n11\n12";
+
+// Day options (01-31)
+static const char *DAY_OPTIONS =
+    "01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n11\n12\n13\n14\n15\n"
+    "16\n17\n18\n19\n20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n30\n31";
+
+// Hour options (00-23)
+static const char *HOUR_OPTIONS =
+    "00\n01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n11\n"
+    "12\n13\n14\n15\n16\n17\n18\n19\n20\n21\n22\n23";
+
+// Minute options (00-59)
+static const char *MINUTE_OPTIONS =
+    "00\n01\n02\n03\n04\n05\n06\n07\n08\n09\n"
+    "10\n11\n12\n13\n14\n15\n16\n17\n18\n19\n"
+    "20\n21\n22\n23\n24\n25\n26\n27\n28\n29\n"
+    "30\n31\n32\n33\n34\n35\n36\n37\n38\n39\n"
+    "40\n41\n42\n43\n44\n45\n46\n47\n48\n49\n"
+    "50\n51\n52\n53\n54\n55\n56\n57\n58\n59";
+
+// NTP server options
+static const char *NTP_SERVER_OPTIONS = "NICT (ntp.nict.jp)\nGoogle (time.google.com)";
+
+/**
+ * @brief Update WiFi status label
+ */
+static void update_wifi_status(void)
+{
+    if (!s_wifi_status_label) return;
+
+    char status[64];
+    network_state_t state = network_get_state();
+
+    switch (state) {
+    case NETWORK_STATE_CONNECTED: {
+        char ip[16];
+        if (network_get_ip(ip, sizeof(ip)) == ESP_OK) {
+            snprintf(status, sizeof(status), "Connected (%s)", ip);
+        } else {
+            snprintf(status, sizeof(status), "Connected");
+        }
+        lv_obj_set_style_text_color(s_wifi_status_label, lv_color_hex(0x00FF00), 0);
+        break;
+    }
+    case NETWORK_STATE_CONNECTING:
+        snprintf(status, sizeof(status), "Connecting...");
+        lv_obj_set_style_text_color(s_wifi_status_label, lv_color_hex(0xFFFF00), 0);
+        break;
+    case NETWORK_STATE_ERROR:
+        snprintf(status, sizeof(status), "Connection Failed");
+        lv_obj_set_style_text_color(s_wifi_status_label, lv_color_hex(0xFF6666), 0);
+        break;
+    case NETWORK_STATE_DISCONNECTED:
+    default:
+        snprintf(status, sizeof(status), "Disconnected");
+        lv_obj_set_style_text_color(s_wifi_status_label, lv_color_hex(0xAAAAAA), 0);
+        break;
+    }
+
+    lv_label_set_text(s_wifi_status_label, status);
+}
+
+/**
+ * @brief NTP sync button callback
+ */
+static void sync_btn_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_RELEASED) return;
+
+    if (!network_is_connected()) {
+        if (s_sync_status_label) {
+            lv_label_set_text(s_sync_status_label, "WiFi not connected!");
+            lv_obj_set_style_text_color(s_sync_status_label, lv_color_hex(0xFF6666), 0);
+        }
+        return;
+    }
+
+    // Get selected server
+    ntp_server_t server = (ntp_server_t)lv_dropdown_get_selected(s_ntp_dropdown);
+
+    if (s_sync_status_label) {
+        lv_label_set_text(s_sync_status_label, "Syncing...");
+        lv_obj_set_style_text_color(s_sync_status_label, lv_color_hex(0xFFFF00), 0);
+    }
+
+    ESP_LOGI(TAG, "Starting NTP sync with server %d", server);
+
+    // ntp_sync() is now async - it returns immediately after starting sync
+    // Sync status will be updated via ui_network_update() polling
+    esp_err_t ret = ntp_sync(server);
+    if (ret != ESP_OK) {
+        // Only show error if sync couldn't start (e.g., not connected)
+        if (s_sync_status_label) {
+            lv_label_set_text(s_sync_status_label, "Sync failed to start!");
+            lv_obj_set_style_text_color(s_sync_status_label, lv_color_hex(0xFF6666), 0);
+        }
+    }
+    // If ret == ESP_OK, status remains "Syncing..." until update_ntp_status() updates it
+}
+
+/**
+ * @brief NTP server dropdown callback
+ */
+static void ntp_server_changed_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
+
+    ntp_server_t server = (ntp_server_t)lv_dropdown_get_selected(s_ntp_dropdown);
+    ntp_set_default_server(server);
+    ESP_LOGI(TAG, "NTP server changed to: %s", ntp_get_server_name(server));
+}
+
+/**
+ * @brief Manual time set button callback
+ */
+static void manual_set_btn_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_RELEASED) return;
+
+    struct tm time;
+    memset(&time, 0, sizeof(time));
+
+    // Get values from dropdowns
+    time.tm_year = lv_dropdown_get_selected(s_year_dropdown) + 2024 - 1900;
+    time.tm_mon = lv_dropdown_get_selected(s_month_dropdown);
+    time.tm_mday = lv_dropdown_get_selected(s_day_dropdown) + 1;
+    time.tm_hour = lv_dropdown_get_selected(s_hour_dropdown);
+    time.tm_min = lv_dropdown_get_selected(s_minute_dropdown);
+    time.tm_sec = 0;
+
+    ESP_LOGI(TAG, "Setting manual time: %04d-%02d-%02d %02d:%02d",
+             time.tm_year + 1900, time.tm_mon + 1, time.tm_mday,
+             time.tm_hour, time.tm_min);
+
+    esp_err_t ret = ntp_set_time_manual(&time);
+    if (ret == ESP_OK) {
+        if (s_sync_status_label) {
+            lv_label_set_text(s_sync_status_label, "Time set!");
+            lv_obj_set_style_text_color(s_sync_status_label, lv_color_hex(0x00FF00), 0);
+        }
+    } else {
+        if (s_sync_status_label) {
+            lv_label_set_text(s_sync_status_label, "Failed to set time!");
+            lv_obj_set_style_text_color(s_sync_status_label, lv_color_hex(0xFF6666), 0);
+        }
+    }
+}
+
+/**
+ * @brief WOL send button callback
+ */
+static void wol_btn_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_RELEASED) return;
+
+    wol_result_t result = wol_send_default();
+
+    switch (result) {
+    case WOL_RESULT_OK:
+        ESP_LOGI(TAG, "WOL packet sent successfully");
+        // Brief visual feedback on button
+        lv_obj_set_style_bg_color(s_wol_btn, lv_color_hex(0x00FF00), 0);
+        break;
+    case WOL_RESULT_NOT_CONNECTED:
+        ESP_LOGW(TAG, "WOL failed: network not connected");
+        lv_obj_set_style_bg_color(s_wol_btn, lv_color_hex(0xFF6666), 0);
+        break;
+    case WOL_RESULT_INVALID_MAC:
+        ESP_LOGW(TAG, "WOL failed: invalid MAC");
+        lv_obj_set_style_bg_color(s_wol_btn, lv_color_hex(0xFF6666), 0);
+        break;
+    default:
+        ESP_LOGE(TAG, "WOL failed: send error");
+        lv_obj_set_style_bg_color(s_wol_btn, lv_color_hex(0xFF6666), 0);
+        break;
+    }
+}
+
+/**
+ * @brief Set current time to dropdown selections
+ */
+static void set_current_time_to_dropdowns(void)
+{
+    time_t now;
+    struct tm timeinfo;
+    time(&now);
+    localtime_r(&now, &timeinfo);
+
+    // Set year (2024 = index 0)
+    int year_idx = timeinfo.tm_year + 1900 - 2024;
+    if (year_idx >= 0 && year_idx < 12) {
+        lv_dropdown_set_selected(s_year_dropdown, year_idx);
+    }
+
+    lv_dropdown_set_selected(s_month_dropdown, timeinfo.tm_mon);
+    lv_dropdown_set_selected(s_day_dropdown, timeinfo.tm_mday - 1);
+    lv_dropdown_set_selected(s_hour_dropdown, timeinfo.tm_hour);
+    lv_dropdown_set_selected(s_minute_dropdown, timeinfo.tm_min);
+}
+
+void ui_network_init(lv_obj_t *parent)
+{
+    if (!parent) return;
+
+    ESP_LOGI(TAG, "Initializing network UI");
+
+    // Create network settings section
+    s_network_panel = lv_obj_create(parent);
+    lv_obj_set_size(s_network_panel, LV_PCT(100), LV_SIZE_CONTENT);
+    lv_obj_set_flex_flow(s_network_panel, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(s_network_panel, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(s_network_panel, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(s_network_panel, 0, 0);
+    lv_obj_set_style_pad_all(s_network_panel, 0, 0);
+    lv_obj_set_style_pad_row(s_network_panel, 10, 0);
+
+    // ========== Network & Time Title ==========
+    lv_obj_t *title = lv_label_create(s_network_panel);
+    lv_label_set_text(title, "Network & Time");
+    lv_obj_set_style_text_font(title, &lv_font_montserrat_18, 0);
+    lv_obj_set_style_text_color(title, lv_color_hex(0xFFFFFF), 0);
+
+    // ========== WiFi Status ==========
+    lv_obj_t *wifi_row = lv_obj_create(s_network_panel);
+    lv_obj_set_size(wifi_row, 280, 40);
+    lv_obj_set_flex_flow(wifi_row, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(wifi_row, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(wifi_row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(wifi_row, 0, 0);
+    lv_obj_set_style_pad_all(wifi_row, 0, 0);
+
+    lv_obj_t *wifi_label = lv_label_create(wifi_row);
+    lv_label_set_text(wifi_label, "WiFi:");
+    lv_obj_set_style_text_font(wifi_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(wifi_label, lv_color_hex(0xFFFFFF), 0);
+
+    s_wifi_status_label = lv_label_create(wifi_row);
+    lv_label_set_text(s_wifi_status_label, "Checking...");
+    lv_obj_set_style_text_font(s_wifi_status_label, &lv_font_montserrat_14, 0);
+
+    // ========== NTP Server Selection ==========
+    lv_obj_t *ntp_label = lv_label_create(s_network_panel);
+    lv_label_set_text(ntp_label, "NTP Server:");
+    lv_obj_set_style_text_font(ntp_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(ntp_label, lv_color_hex(0xFFFFFF), 0);
+
+    s_ntp_dropdown = lv_dropdown_create(s_network_panel);
+    lv_dropdown_set_options(s_ntp_dropdown, NTP_SERVER_OPTIONS);
+    lv_dropdown_set_selected(s_ntp_dropdown, ntp_get_default_server());
+    lv_obj_set_width(s_ntp_dropdown, 250);
+    lv_obj_set_style_text_font(s_ntp_dropdown, &lv_font_montserrat_14, 0);
+    lv_obj_add_event_cb(s_ntp_dropdown, ntp_server_changed_cb, LV_EVENT_VALUE_CHANGED, NULL);
+
+    // Sync button row
+    lv_obj_t *sync_row = lv_obj_create(s_network_panel);
+    lv_obj_set_size(sync_row, 280, 50);
+    lv_obj_set_flex_flow(sync_row, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(sync_row, LV_FLEX_ALIGN_SPACE_BETWEEN, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(sync_row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(sync_row, 0, 0);
+    lv_obj_set_style_pad_all(sync_row, 0, 0);
+
+    s_sync_btn = lv_button_create(sync_row);
+    lv_obj_set_size(s_sync_btn, 120, 40);
+    lv_obj_add_event_cb(s_sync_btn, sync_btn_cb, LV_EVENT_RELEASED, NULL);
+    lv_obj_set_style_bg_color(s_sync_btn, lv_color_hex(0x2196F3), 0);
+
+    lv_obj_t *sync_btn_label = lv_label_create(s_sync_btn);
+    lv_label_set_text(sync_btn_label, "Sync Now");
+    lv_obj_set_style_text_font(sync_btn_label, &lv_font_montserrat_14, 0);
+    lv_obj_center(sync_btn_label);
+
+    s_sync_status_label = lv_label_create(sync_row);
+    lv_label_set_text(s_sync_status_label, "");
+    lv_obj_set_style_text_font(s_sync_status_label, &lv_font_montserrat_12, 0);
+
+    // ========== Manual Time Section ==========
+    lv_obj_t *manual_label = lv_label_create(s_network_panel);
+    lv_label_set_text(manual_label, "Manual Time:");
+    lv_obj_set_style_text_font(manual_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(manual_label, lv_color_hex(0xFFFFFF), 0);
+
+    // Date row: Year Month Day
+    lv_obj_t *date_row = lv_obj_create(s_network_panel);
+    lv_obj_set_size(date_row, 280, 50);
+    lv_obj_set_flex_flow(date_row, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(date_row, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(date_row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(date_row, 0, 0);
+    lv_obj_set_style_pad_all(date_row, 0, 0);
+    lv_obj_set_style_pad_column(date_row, 8, 0);
+
+    s_year_dropdown = lv_dropdown_create(date_row);
+    lv_dropdown_set_options(s_year_dropdown, YEAR_OPTIONS);
+    lv_obj_set_width(s_year_dropdown, 85);
+    lv_obj_set_style_text_font(s_year_dropdown, &lv_font_montserrat_14, 0);
+
+    s_month_dropdown = lv_dropdown_create(date_row);
+    lv_dropdown_set_options(s_month_dropdown, MONTH_OPTIONS);
+    lv_obj_set_width(s_month_dropdown, 65);
+    lv_obj_set_style_text_font(s_month_dropdown, &lv_font_montserrat_14, 0);
+
+    s_day_dropdown = lv_dropdown_create(date_row);
+    lv_dropdown_set_options(s_day_dropdown, DAY_OPTIONS);
+    lv_obj_set_width(s_day_dropdown, 65);
+    lv_obj_set_style_text_font(s_day_dropdown, &lv_font_montserrat_14, 0);
+
+    // Time row: Hour : Minute
+    lv_obj_t *time_row = lv_obj_create(s_network_panel);
+    lv_obj_set_size(time_row, 280, 50);
+    lv_obj_set_flex_flow(time_row, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(time_row, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(time_row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(time_row, 0, 0);
+    lv_obj_set_style_pad_all(time_row, 0, 0);
+    lv_obj_set_style_pad_column(time_row, 8, 0);
+
+    s_hour_dropdown = lv_dropdown_create(time_row);
+    lv_dropdown_set_options(s_hour_dropdown, HOUR_OPTIONS);
+    lv_obj_set_width(s_hour_dropdown, 80);
+    lv_obj_set_style_text_font(s_hour_dropdown, &lv_font_montserrat_14, 0);
+
+    lv_obj_t *colon = lv_label_create(time_row);
+    lv_label_set_text(colon, ":");
+    lv_obj_set_style_text_font(colon, &lv_font_montserrat_18, 0);
+    lv_obj_set_style_text_color(colon, lv_color_hex(0xFFFFFF), 0);
+
+    s_minute_dropdown = lv_dropdown_create(time_row);
+    lv_dropdown_set_options(s_minute_dropdown, MINUTE_OPTIONS);
+    lv_obj_set_width(s_minute_dropdown, 80);
+    lv_obj_set_style_text_font(s_minute_dropdown, &lv_font_montserrat_14, 0);
+
+    // Set current time to dropdowns
+    set_current_time_to_dropdowns();
+
+    // Set Manual button
+    s_manual_set_btn = lv_button_create(s_network_panel);
+    lv_obj_set_size(s_manual_set_btn, 140, 40);
+    lv_obj_add_event_cb(s_manual_set_btn, manual_set_btn_cb, LV_EVENT_RELEASED, NULL);
+    lv_obj_set_style_bg_color(s_manual_set_btn, lv_color_hex(0x757575), 0);
+
+    lv_obj_t *manual_btn_label = lv_label_create(s_manual_set_btn);
+    lv_label_set_text(manual_btn_label, "Set Manual");
+    lv_obj_set_style_text_font(manual_btn_label, &lv_font_montserrat_14, 0);
+    lv_obj_center(manual_btn_label);
+
+    // ========== WOL Section ==========
+    lv_obj_t *wol_separator = lv_obj_create(s_network_panel);
+    lv_obj_set_size(wol_separator, 200, 2);
+    lv_obj_set_style_bg_color(wol_separator, lv_color_hex(0x444444), 0);
+    lv_obj_set_style_border_width(wol_separator, 0, 0);
+    lv_obj_set_style_pad_all(wol_separator, 0, 0);
+
+    lv_obj_t *wol_title = lv_label_create(s_network_panel);
+    lv_label_set_text(wol_title, "Wake-on-LAN");
+    lv_obj_set_style_text_font(wol_title, &lv_font_montserrat_18, 0);
+    lv_obj_set_style_text_color(wol_title, lv_color_hex(0xFFFFFF), 0);
+
+    // Target MAC display
+    char mac_str[20] = "Not configured";
+    wol_get_default_mac_str(mac_str, sizeof(mac_str));
+
+    lv_obj_t *target_row = lv_obj_create(s_network_panel);
+    lv_obj_set_size(target_row, 280, 30);
+    lv_obj_set_flex_flow(target_row, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(target_row, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(target_row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(target_row, 0, 0);
+    lv_obj_set_style_pad_all(target_row, 0, 0);
+    lv_obj_set_style_pad_column(target_row, 8, 0);
+
+    lv_obj_t *target_label = lv_label_create(target_row);
+    lv_label_set_text(target_label, "Target:");
+    lv_obj_set_style_text_font(target_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(target_label, lv_color_hex(0xFFFFFF), 0);
+
+    s_wol_target_label = lv_label_create(target_row);
+    lv_label_set_text(s_wol_target_label, mac_str);
+    lv_obj_set_style_text_font(s_wol_target_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(s_wol_target_label, lv_color_hex(0xAAAAAA), 0);
+
+    // Send WOL button
+    s_wol_btn = lv_button_create(s_network_panel);
+    lv_obj_set_size(s_wol_btn, 140, 40);
+    lv_obj_add_event_cb(s_wol_btn, wol_btn_cb, LV_EVENT_RELEASED, NULL);
+    lv_obj_set_style_bg_color(s_wol_btn, lv_color_hex(0xFF9800), 0);
+
+    lv_obj_t *wol_btn_label = lv_label_create(s_wol_btn);
+    lv_label_set_text(wol_btn_label, "Send WOL");
+    lv_obj_set_style_text_font(wol_btn_label, &lv_font_montserrat_14, 0);
+    lv_obj_center(wol_btn_label);
+
+    // Initial status update
+    update_wifi_status();
+
+    ESP_LOGI(TAG, "Network UI initialized");
+}
+
+void ui_network_deinit(void)
+{
+    s_network_panel = NULL;
+    s_wifi_status_label = NULL;
+    s_ntp_dropdown = NULL;
+    s_sync_btn = NULL;
+    s_sync_status_label = NULL;
+    s_year_dropdown = NULL;
+    s_month_dropdown = NULL;
+    s_day_dropdown = NULL;
+    s_hour_dropdown = NULL;
+    s_minute_dropdown = NULL;
+    s_manual_set_btn = NULL;
+    s_wol_target_label = NULL;
+    s_wol_btn = NULL;
+
+    ESP_LOGI(TAG, "Network UI deinitialized");
+}
+
+void ui_network_update(void)
+{
+    update_wifi_status();
+
+    // Update NTP sync status label based on current NTP state
+    if (s_sync_status_label) {
+        ntp_status_t ntp_status = ntp_get_status();
+        static ntp_status_t last_ntp_status = NTP_STATUS_IDLE;
+
+        if (ntp_status != last_ntp_status) {
+            last_ntp_status = ntp_status;
+
+            switch (ntp_status) {
+            case NTP_STATUS_SYNCED:
+                lv_label_set_text(s_sync_status_label, "Synced!");
+                lv_obj_set_style_text_color(s_sync_status_label, lv_color_hex(0x00FF00), 0);
+                break;
+            case NTP_STATUS_SYNCING:
+                lv_label_set_text(s_sync_status_label, "Syncing...");
+                lv_obj_set_style_text_color(s_sync_status_label, lv_color_hex(0xFFFF00), 0);
+                break;
+            case NTP_STATUS_FAILED:
+                lv_label_set_text(s_sync_status_label, "Sync failed!");
+                lv_obj_set_style_text_color(s_sync_status_label, lv_color_hex(0xFF6666), 0);
+                break;
+            case NTP_STATUS_IDLE:
+            default:
+                // Keep current text
+                break;
+            }
+        }
+    }
+
+    // Reset WOL button color after press
+    if (s_wol_btn) {
+        lv_obj_set_style_bg_color(s_wol_btn, lv_color_hex(0xFF9800), 0);
+    }
+}

--- a/03.firmware/04.integratedAPP/components/ui/ui_network.h
+++ b/03.firmware/04.integratedAPP/components/ui/ui_network.h
@@ -1,0 +1,37 @@
+/**
+ * @file ui_network.h
+ * @brief Network Settings UI - WiFi, NTP, and WOL controls
+ */
+
+#pragma once
+
+#include "lvgl.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Initialize network settings UI
+ *
+ * Creates the Network & Time settings section in the parent container.
+ *
+ * @param[in] parent Parent LVGL object to add UI to
+ */
+void ui_network_init(lv_obj_t *parent);
+
+/**
+ * @brief Deinitialize network settings UI
+ */
+void ui_network_deinit(void);
+
+/**
+ * @brief Update network UI state
+ *
+ * Call periodically to refresh WiFi status, sync status, etc.
+ */
+void ui_network_update(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/03.firmware/04.integratedAPP/main/Kconfig.projbuild
+++ b/03.firmware/04.integratedAPP/main/Kconfig.projbuild
@@ -1,0 +1,40 @@
+menu "Handy Keyboard Network"
+
+    config HANDY_WOL_DEFAULT_MAC
+        string "Wake-on-LAN target MAC address"
+        default "AA:BB:CC:DD:EE:FF"
+        help
+            Default target MAC address for Wake-on-LAN packets.
+            Format: "AA:BB:CC:DD:EE:FF" or "AA-BB-CC-DD-EE-FF"
+
+    config HANDY_WIFI_SSID
+        string "WiFi SSID"
+        default ""
+        help
+            Default WiFi network SSID to connect to.
+            Leave empty to require manual configuration.
+
+    config HANDY_WIFI_PASSWORD
+        string "WiFi Password"
+        default ""
+        help
+            Default WiFi network password.
+            Leave empty for open networks.
+
+    config HANDY_NTP_DEFAULT_SERVER
+        int "Default NTP server (0=NICT, 1=Google)"
+        default 0
+        range 0 1
+        help
+            Default NTP server for time synchronization.
+            0 = NICT Japan (ntp.nict.jp)
+            1 = Google (time.google.com)
+
+    config HANDY_NETWORK_AUTO_CONNECT
+        bool "Auto-connect WiFi on startup"
+        default y
+        help
+            If enabled and SSID is configured, automatically
+            connect to WiFi during startup.
+
+endmenu

--- a/03.firmware/04.integratedAPP/main/main.c
+++ b/03.firmware/04.integratedAPP/main/main.c
@@ -48,6 +48,11 @@
 // Alarm
 #include "alarm.h"
 
+// Network
+#include "network.h"
+#include "ntp.h"
+#include "wol.h"
+
 static const char *TAG = "HANDY_KEYBOARD";
 
 // LVGL display handle
@@ -224,6 +229,41 @@ void app_main(void)
 
     // Initialize RTC using BSP I2C handle
     rtc_init();
+
+    // Initialize network subsystem (WiFi via ESP-Hosted)
+    ESP_LOGI(TAG, "Initializing network subsystem...");
+    esp_err_t net_ret = network_init();
+    if (net_ret != ESP_OK) {
+        ESP_LOGW(TAG, "Network init failed: %s", esp_err_to_name(net_ret));
+    } else {
+        ESP_LOGI(TAG, "Network subsystem initialized");
+
+        // Auto-connect if configured
+#if defined(CONFIG_HANDY_NETWORK_AUTO_CONNECT) && defined(CONFIG_HANDY_WIFI_SSID)
+        if (strlen(CONFIG_HANDY_WIFI_SSID) > 0) {
+            ESP_LOGI(TAG, "Auto-connecting to WiFi: %s", CONFIG_HANDY_WIFI_SSID);
+            network_connect(CONFIG_HANDY_WIFI_SSID, CONFIG_HANDY_WIFI_PASSWORD);
+        }
+#endif
+    }
+
+    // Initialize NTP subsystem (with RTC handle for time writeback)
+    ESP_LOGI(TAG, "Initializing NTP subsystem...");
+    esp_err_t ntp_ret = ntp_init(g_rtc_initialized ? &g_rtc_handle : NULL);
+    if (ntp_ret != ESP_OK) {
+        ESP_LOGW(TAG, "NTP init failed: %s", esp_err_to_name(ntp_ret));
+    } else {
+        ESP_LOGI(TAG, "NTP subsystem initialized");
+    }
+
+    // Initialize WOL subsystem
+    ESP_LOGI(TAG, "Initializing WOL subsystem...");
+    esp_err_t wol_ret = wol_init();
+    if (wol_ret != ESP_OK) {
+        ESP_LOGW(TAG, "WOL init failed: %s", esp_err_to_name(wol_ret));
+    } else {
+        ESP_LOGI(TAG, "WOL subsystem initialized");
+    }
 
     // Initialize alarm system (uses audio player and NVS)
     ESP_LOGI(TAG, "Initializing alarm system...");

--- a/03.firmware/04.integratedAPP/sdkconfig.defaults
+++ b/03.firmware/04.integratedAPP/sdkconfig.defaults
@@ -231,3 +231,19 @@ CONFIG_FATFS_MAX_LFN=255
 # I2C configuration (GPIO7=SDA, GPIO8=SCL)
 # Devices: DS3231M RTC (0x68), ES8311 Audio Codec (0x18), GT911 Touch (0x5D)
 CONFIG_I2C_ENABLE_DEBUG_LOG=n
+
+# =============================================================================
+# 15. Network Settings (WiFi, NTP, WOL)
+# =============================================================================
+
+# WiFi credentials (2.4GHz only via ESP32-C6)
+# Set via menuconfig or sdkconfig.local (not committed to git)
+# CONFIG_HANDY_WIFI_SSID=""
+# CONFIG_HANDY_WIFI_PASSWORD=""
+CONFIG_HANDY_NETWORK_AUTO_CONNECT=y
+
+# NTP server (0=NICT Japan, 1=Google)
+CONFIG_HANDY_NTP_DEFAULT_SERVER=0
+
+# Wake-on-LAN default target MAC
+CONFIG_HANDY_WOL_DEFAULT_MAC="AA:BB:CC:DD:EE:FF"


### PR DESCRIPTION
## Summary
- Add WiFi connectivity via ESP-Hosted (ESP32-C6 coprocessor)
- Add NTP time synchronization with NICT/Google servers (async, non-blocking)
- Add Wake-on-LAN magic packet support for remote PC wake
- Add Settings UI for network configuration

## Changes
- **New component**: `network/` - WiFi connection, NTP sync, WOL
- **New UI**: `ui_network.c/h` - Settings panel for network features
- **Modified**: `main.c` - Initialize network subsystems
- **Modified**: `ui_navigation.c` - Periodic network status updates
- **New**: `Kconfig.projbuild` - Network configuration options

## Test plan
- [x] WiFi auto-connect on startup
- [x] WiFi status display (Connected/Disconnected)
- [x] NTP sync button (async, no UI blocking)
- [x] DS3231M RTC updated from NTP
- [x] WOL magic packet sent successfully (PC woke up)

## Security
- WiFi credentials are NOT committed (empty defaults in Kconfig)
- Users configure via `idf.py menuconfig` or `sdkconfig.local` (gitignored)
- WOL default MAC is dummy value `AA:BB:CC:DD:EE:FF`

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/claude-code)