### PR TITLE
feat: Network feature improvements (Issue #22)

### DIFF
--- a/03.firmware/04.integratedAPP/components/network/include/network.h
+++ b/03.firmware/04.integratedAPP/components/network/include/network.h
@@ -11,10 +11,14 @@
 #include <stdbool.h>
 #include "esp_err.h"
 #include "esp_netif.h"
+#include "esp_wifi_types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** Maximum number of scan results to return */
+#define MAX_SCAN_RESULTS 10
 
 /**
  * @brief Network connection state
@@ -25,6 +29,20 @@ typedef enum {
     NETWORK_STATE_CONNECTED,
     NETWORK_STATE_ERROR,
 } network_state_t;
+
+/**
+ * @brief WiFi scan result entry
+ */
+typedef struct {
+    char ssid[33];              ///< SSID (null-terminated)
+    int8_t rssi;                ///< Signal strength in dBm
+    wifi_auth_mode_t authmode;  ///< Authentication mode
+} network_scan_result_t;
+
+/**
+ * @brief WiFi scan complete callback type
+ */
+typedef void (*network_scan_cb_t)(network_scan_result_t *results, uint16_t count);
 
 /**
  * @brief Network event callback type
@@ -123,6 +141,41 @@ bool network_has_saved_credentials(void);
  * @param[in] cb Callback function
  */
 void network_register_callback(network_event_cb_t cb);
+
+/**
+ * @brief Start WiFi network scan
+ *
+ * Initiates an asynchronous scan for available WiFi networks.
+ * Results are delivered via the callback.
+ *
+ * @param[in] callback Function to call with scan results
+ * @return ESP_OK if scan started, ESP_ERR_INVALID_STATE if already scanning
+ */
+esp_err_t network_scan_start(network_scan_cb_t callback);
+
+/**
+ * @brief Check if WiFi scan is in progress
+ *
+ * @return true if scanning
+ */
+bool network_is_scanning(void);
+
+/**
+ * @brief Check if ESP-Hosted coprocessor is available
+ *
+ * @return true if coprocessor is connected and functional
+ */
+bool network_is_coprocessor_available(void);
+
+/**
+ * @brief Reset ESP-Hosted coprocessor connection
+ *
+ * Attempts to re-initialize the WiFi subsystem to recover from
+ * coprocessor communication errors.
+ *
+ * @return ESP_OK on success
+ */
+esp_err_t network_reset_coprocessor(void);
 
 #ifdef __cplusplus
 }

--- a/03.firmware/04.integratedAPP/components/network/include/ntp.h
+++ b/03.firmware/04.integratedAPP/components/network/include/ntp.h
@@ -116,6 +116,23 @@ const char *ntp_get_server_name(ntp_server_t server);
  */
 void ntp_register_callback(ntp_sync_cb_t cb);
 
+/**
+ * @brief Set NTP sync timeout
+ *
+ * If sync doesn't complete within timeout, status changes to NTP_STATUS_FAILED.
+ *
+ * @param[in] timeout_ms Timeout in milliseconds (1000-300000, default 30000)
+ * @return ESP_OK on success, ESP_ERR_INVALID_ARG if out of range
+ */
+esp_err_t ntp_set_timeout(uint32_t timeout_ms);
+
+/**
+ * @brief Get current NTP sync timeout
+ *
+ * @return Timeout in milliseconds
+ */
+uint32_t ntp_get_timeout(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/03.firmware/04.integratedAPP/components/network/src/network.c
+++ b/03.firmware/04.integratedAPP/components/network/src/network.c
@@ -13,9 +13,15 @@
 #include "nvs.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/event_groups.h"
+#include "freertos/timers.h"
 #include <string.h>
 
 static const char *TAG = "NETWORK";
+
+// Exponential backoff configuration
+#define INITIAL_BACKOFF_MS     1000   // 1 second
+#define MAX_BACKOFF_MS         60000  // 60 seconds
+#define BACKOFF_MULTIPLIER     2
 
 // NVS namespace and keys
 #define NVS_NAMESPACE "network"
@@ -36,9 +42,84 @@ static network_event_cb_t g_event_callback = NULL;
 static int g_retry_count = 0;
 static const int MAX_RETRY = 5;
 
+// Exponential backoff reconnection
+static TimerHandle_t g_reconnect_timer = NULL;
+static uint32_t g_backoff_ms = INITIAL_BACKOFF_MS;
+
 // Current connection info
 static char g_current_ssid[33] = {0};
 static esp_netif_ip_info_t g_ip_info;
+
+// WiFi scan state
+static network_scan_cb_t g_scan_callback = NULL;
+static bool g_scanning = false;
+
+// Coprocessor status
+static bool g_coprocessor_available = false;
+
+/**
+ * @brief Handle scan complete event
+ */
+static void handle_scan_done(void)
+{
+    uint16_t ap_count = 0;
+    esp_wifi_scan_get_ap_num(&ap_count);
+
+    ESP_LOGI(TAG, "Scan complete, found %d networks", ap_count);
+
+    if (ap_count > MAX_SCAN_RESULTS) {
+        ap_count = MAX_SCAN_RESULTS;
+    }
+
+    network_scan_result_t results[MAX_SCAN_RESULTS];
+    memset(results, 0, sizeof(results));
+
+    if (ap_count > 0) {
+        wifi_ap_record_t *ap_list = malloc(sizeof(wifi_ap_record_t) * ap_count);
+        if (ap_list) {
+            uint16_t max_records = ap_count;
+            esp_err_t ret = esp_wifi_scan_get_ap_records(&max_records, ap_list);
+            if (ret == ESP_OK) {
+                for (int i = 0; i < max_records; i++) {
+                    strncpy(results[i].ssid, (char *)ap_list[i].ssid, 32);
+                    results[i].ssid[32] = '\0';
+                    results[i].rssi = ap_list[i].rssi;
+                    results[i].authmode = ap_list[i].authmode;
+                }
+                ap_count = max_records;
+            } else {
+                ESP_LOGE(TAG, "Failed to get scan records: %s", esp_err_to_name(ret));
+                ap_count = 0;
+            }
+            free(ap_list);
+        } else {
+            ESP_LOGE(TAG, "Failed to allocate memory for scan results");
+            ap_count = 0;
+        }
+    }
+
+    g_scanning = false;
+
+    if (g_scan_callback) {
+        g_scan_callback(results, ap_count);
+    }
+}
+
+/**
+ * @brief Reconnect timer callback for exponential backoff
+ */
+static void reconnect_timer_cb(TimerHandle_t xTimer)
+{
+    (void)xTimer;
+
+    if (g_connect_requested && g_retry_count < MAX_RETRY) {
+        ESP_LOGI(TAG, "Attempting reconnection...");
+        esp_err_t ret = esp_wifi_connect();
+        if (ret != ESP_OK) {
+            ESP_LOGE(TAG, "Failed to initiate reconnection: %s", esp_err_to_name(ret));
+        }
+    }
+}
 
 /**
  * @brief WiFi event handler
@@ -57,14 +138,40 @@ static void wifi_event_handler(void *arg, esp_event_base_t event_base,
         // Only retry if connection was explicitly requested
         if (g_connect_requested && g_retry_count < MAX_RETRY) {
             g_retry_count++;
-            ESP_LOGI(TAG, "Retrying connection (%d/%d)...", g_retry_count, MAX_RETRY);
-            esp_wifi_connect();
+
+            // Calculate backoff delay
+            uint32_t backoff = g_backoff_ms;
+            ESP_LOGI(TAG, "Reconnecting in %lu ms (attempt %d/%d)",
+                     (unsigned long)backoff, g_retry_count, MAX_RETRY);
+
+            // Update backoff for next attempt (exponential)
+            g_backoff_ms = g_backoff_ms * BACKOFF_MULTIPLIER;
+            if (g_backoff_ms > MAX_BACKOFF_MS) {
+                g_backoff_ms = MAX_BACKOFF_MS;
+            }
+
+            // Schedule delayed reconnection
+            if (!g_reconnect_timer) {
+                g_reconnect_timer = xTimerCreate("wifi_reconnect",
+                                                  pdMS_TO_TICKS(backoff),
+                                                  pdFALSE,  // One-shot timer
+                                                  NULL,
+                                                  reconnect_timer_cb);
+            } else {
+                xTimerChangePeriod(g_reconnect_timer, pdMS_TO_TICKS(backoff), 0);
+            }
+
+            if (g_reconnect_timer) {
+                xTimerStart(g_reconnect_timer, 0);
+            }
+
             g_state = NETWORK_STATE_CONNECTING;
         } else if (g_connect_requested) {
             ESP_LOGE(TAG, "Connection failed after %d retries", MAX_RETRY);
             xEventGroupSetBits(g_wifi_event_group, WIFI_FAIL_BIT);
             g_state = NETWORK_STATE_ERROR;
             g_connect_requested = false;
+            g_backoff_ms = INITIAL_BACKOFF_MS;  // Reset for next connection attempt
         } else {
             g_state = NETWORK_STATE_DISCONNECTED;
         }
@@ -76,7 +183,10 @@ static void wifi_event_handler(void *arg, esp_event_base_t event_base,
         wifi_event_sta_connected_t *event = (wifi_event_sta_connected_t *)event_data;
         ESP_LOGI(TAG, "Connected to AP: %s", event->ssid);
         g_retry_count = 0;
+        g_backoff_ms = INITIAL_BACKOFF_MS;  // Reset backoff on successful connection
         // Wait for IP before setting CONNECTED state
+    } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_SCAN_DONE) {
+        handle_scan_done();
     }
 }
 
@@ -111,14 +221,23 @@ esp_err_t network_init(void)
 
     ESP_LOGI(TAG, "Initializing network subsystem...");
 
-    // Verify ESP-Hosted coprocessor is connected
-    // (BLE HID init should have already established this connection)
-    esp_hosted_coprocessor_fwver_t fwver;
-    if (esp_hosted_get_coprocessor_fwversion(&fwver) == ESP_OK) {
-        ESP_LOGI(TAG, "ESP-Hosted coprocessor FW: %lu.%lu.%lu",
-                 fwver.major1, fwver.minor1, fwver.patch1);
-    } else {
-        ESP_LOGW(TAG, "Could not get ESP-Hosted coprocessor version - WiFi may not work");
+    // Verify ESP-Hosted coprocessor is connected with retries
+    g_coprocessor_available = false;
+    for (int retry = 0; retry < 3; retry++) {
+        esp_hosted_coprocessor_fwver_t fwver;
+        if (esp_hosted_get_coprocessor_fwversion(&fwver) == ESP_OK) {
+            g_coprocessor_available = true;
+            ESP_LOGI(TAG, "ESP-Hosted coprocessor FW: %lu.%lu.%lu",
+                     fwver.major1, fwver.minor1, fwver.patch1);
+            break;
+        }
+        ESP_LOGW(TAG, "Coprocessor check failed, retry %d/3", retry + 1);
+        vTaskDelay(pdMS_TO_TICKS(500));
+    }
+
+    if (!g_coprocessor_available) {
+        ESP_LOGE(TAG, "ESP-Hosted coprocessor not available - WiFi disabled");
+        return ESP_ERR_NOT_FOUND;
     }
 
     // Create event group
@@ -195,6 +314,13 @@ esp_err_t network_deinit(void)
         return ESP_OK;
     }
 
+    // Stop and delete reconnect timer
+    if (g_reconnect_timer) {
+        xTimerStop(g_reconnect_timer, 0);
+        xTimerDelete(g_reconnect_timer, 0);
+        g_reconnect_timer = NULL;
+    }
+
     esp_wifi_stop();
     esp_wifi_deinit();
 
@@ -210,6 +336,7 @@ esp_err_t network_deinit(void)
 
     g_initialized = false;
     g_state = NETWORK_STATE_DISCONNECTED;
+    g_backoff_ms = INITIAL_BACKOFF_MS;
     ESP_LOGI(TAG, "Network subsystem deinitialized");
 
     return ESP_OK;
@@ -229,6 +356,14 @@ esp_err_t network_connect(const char *ssid, const char *password)
 
     ESP_LOGI(TAG, "Connecting to WiFi: %s", ssid);
 
+    // Disconnect if already connected or connecting
+    if (g_state == NETWORK_STATE_CONNECTED || g_state == NETWORK_STATE_CONNECTING) {
+        ESP_LOGI(TAG, "Disconnecting from current network first");
+        g_connect_requested = false;  // Prevent auto-reconnect during transition
+        esp_wifi_disconnect();
+        vTaskDelay(pdMS_TO_TICKS(100));  // Brief delay for disconnect to complete
+    }
+
     // Store SSID for reference
     strncpy(g_current_ssid, ssid, sizeof(g_current_ssid) - 1);
     g_current_ssid[sizeof(g_current_ssid) - 1] = '\0';
@@ -245,10 +380,16 @@ esp_err_t network_connect(const char *ssid, const char *password)
 
     ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &wifi_config));
 
-    // Reset retry counter and mark connection as requested
+    // Reset retry counter, backoff and mark connection as requested
     g_retry_count = 0;
+    g_backoff_ms = INITIAL_BACKOFF_MS;
     g_connect_requested = true;
     g_state = NETWORK_STATE_CONNECTING;
+
+    // Stop any pending reconnect timer
+    if (g_reconnect_timer) {
+        xTimerStop(g_reconnect_timer, 0);
+    }
 
     // Clear event bits
     xEventGroupClearBits(g_wifi_event_group, WIFI_CONNECTED_BIT | WIFI_FAIL_BIT);
@@ -414,4 +555,67 @@ bool network_has_saved_credentials(void)
 void network_register_callback(network_event_cb_t cb)
 {
     g_event_callback = cb;
+}
+
+esp_err_t network_scan_start(network_scan_cb_t callback)
+{
+    if (!g_initialized) {
+        ESP_LOGE(TAG, "Network not initialized");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    if (g_scanning) {
+        ESP_LOGW(TAG, "Scan already in progress");
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    g_scan_callback = callback;
+    g_scanning = true;
+
+    wifi_scan_config_t scan_config = {
+        .ssid = NULL,
+        .bssid = NULL,
+        .channel = 0,
+        .show_hidden = false,
+        .scan_type = WIFI_SCAN_TYPE_ACTIVE,
+        .scan_time = {
+            .active = {
+                .min = 100,
+                .max = 300,
+            },
+        },
+    };
+
+    ESP_LOGI(TAG, "Starting WiFi scan...");
+    esp_err_t ret = esp_wifi_scan_start(&scan_config, false);  // Non-blocking
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to start scan: %s", esp_err_to_name(ret));
+        g_scanning = false;
+        return ret;
+    }
+
+    return ESP_OK;
+}
+
+bool network_is_scanning(void)
+{
+    return g_scanning;
+}
+
+bool network_is_coprocessor_available(void)
+{
+    return g_coprocessor_available;
+}
+
+esp_err_t network_reset_coprocessor(void)
+{
+    ESP_LOGI(TAG, "Resetting coprocessor connection...");
+
+    // Deinitialize if already initialized
+    if (g_initialized) {
+        network_deinit();
+    }
+
+    // Re-initialize
+    return network_init();
 }

--- a/03.firmware/04.integratedAPP/components/network/src/ntp.c
+++ b/03.firmware/04.integratedAPP/components/network/src/ntp.c
@@ -11,10 +11,14 @@
 #include "nvs.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#include "freertos/timers.h"
 #include <string.h>
 #include <sys/time.h>
 
 static const char *TAG = "NTP";
+
+// Default NTP sync timeout (30 seconds)
+#define DEFAULT_NTP_TIMEOUT_MS 30000
 
 // NVS namespace and keys
 #define NVS_NAMESPACE "network"
@@ -39,11 +43,40 @@ static ds3231m_handle_t *g_rtc_handle = NULL;
 static ntp_sync_cb_t g_sync_callback = NULL;
 static ntp_server_t g_current_server = NTP_SERVER_NICT;
 
+// Timeout timer
+static TimerHandle_t g_timeout_timer = NULL;
+static uint32_t g_timeout_ms = DEFAULT_NTP_TIMEOUT_MS;
+
+/**
+ * @brief NTP sync timeout callback
+ */
+static void ntp_timeout_cb(TimerHandle_t xTimer)
+{
+    (void)xTimer;
+    ESP_LOGE(TAG, "NTP sync timeout after %lu ms", (unsigned long)g_timeout_ms);
+
+    // Stop SNTP operation
+    if (esp_sntp_enabled()) {
+        esp_sntp_stop();
+    }
+
+    g_status = NTP_STATUS_FAILED;
+
+    if (g_sync_callback) {
+        g_sync_callback(g_status);
+    }
+}
+
 /**
  * @brief SNTP time sync notification callback
  */
 static void ntp_sync_notification_cb(struct timeval *tv)
 {
+    // Stop timeout timer on successful sync
+    if (g_timeout_timer) {
+        xTimerStop(g_timeout_timer, 0);
+    }
+
     ESP_LOGI(TAG, "NTP sync completed");
 
     // Get synced time
@@ -112,6 +145,13 @@ esp_err_t ntp_deinit(void)
         return ESP_OK;
     }
 
+    // Stop and delete timeout timer
+    if (g_timeout_timer) {
+        xTimerStop(g_timeout_timer, 0);
+        xTimerDelete(g_timeout_timer, 0);
+        g_timeout_timer = NULL;
+    }
+
     esp_sntp_stop();
     g_initialized = false;
     g_status = NTP_STATUS_IDLE;
@@ -160,6 +200,26 @@ esp_err_t ntp_sync(ntp_server_t server)
     // Start SNTP (non-blocking)
     // Sync completion will be notified via ntp_sync_notification_cb
     esp_sntp_init();
+
+    // Start timeout timer
+    if (!g_timeout_timer) {
+        g_timeout_timer = xTimerCreate("ntp_timeout",
+                                        pdMS_TO_TICKS(g_timeout_ms),
+                                        pdFALSE,  // One-shot timer
+                                        NULL,
+                                        ntp_timeout_cb);
+        if (!g_timeout_timer) {
+            ESP_LOGE(TAG, "Failed to create NTP timeout timer");
+        }
+    } else {
+        // Update period if timeout was changed
+        xTimerChangePeriod(g_timeout_timer, pdMS_TO_TICKS(g_timeout_ms), 0);
+    }
+
+    if (g_timeout_timer) {
+        xTimerStart(g_timeout_timer, 0);
+        ESP_LOGI(TAG, "NTP timeout timer started (%lu ms)", (unsigned long)g_timeout_ms);
+    }
 
     ESP_LOGI(TAG, "NTP sync started (async)");
     return ESP_OK;
@@ -251,4 +311,21 @@ const char *ntp_get_server_name(ntp_server_t server)
 void ntp_register_callback(ntp_sync_cb_t cb)
 {
     g_sync_callback = cb;
+}
+
+esp_err_t ntp_set_timeout(uint32_t timeout_ms)
+{
+    if (timeout_ms < 1000 || timeout_ms > 300000) {
+        ESP_LOGE(TAG, "Invalid timeout: %lu ms (valid range: 1000-300000)", (unsigned long)timeout_ms);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    g_timeout_ms = timeout_ms;
+    ESP_LOGI(TAG, "NTP timeout set to %lu ms", (unsigned long)timeout_ms);
+    return ESP_OK;
+}
+
+uint32_t ntp_get_timeout(void)
+{
+    return g_timeout_ms;
 }

--- a/03.firmware/04.integratedAPP/components/ui/ui_network.c
+++ b/03.firmware/04.integratedAPP/components/ui/ui_network.c
@@ -33,6 +33,31 @@ static lv_obj_t *s_manual_set_btn = NULL;
 static lv_obj_t *s_wol_target_label = NULL;
 static lv_obj_t *s_wol_btn = NULL;
 
+// WiFi scanner elements
+static lv_obj_t *s_scan_btn = NULL;
+static lv_obj_t *s_scan_btn_label = NULL;
+static lv_obj_t *s_network_list = NULL;
+static lv_obj_t *s_password_textarea = NULL;
+static lv_obj_t *s_connect_btn = NULL;
+static lv_obj_t *s_selected_ssid_label = NULL;
+
+// Coprocessor error elements
+static lv_obj_t *s_error_panel = NULL;
+static lv_obj_t *s_retry_btn = NULL;
+
+// On-screen keyboard
+static lv_obj_t *s_keyboard = NULL;
+
+// Selected network for connection
+static char s_selected_ssid[33] = {0};
+
+// Cached scan results for button user_data
+static network_scan_result_t s_cached_results[MAX_SCAN_RESULTS];
+static uint16_t s_cached_count = 0;
+
+// Scan complete flag for thread-safe UI update
+static volatile bool s_scan_complete_pending = false;
+
 // Year options (2024-2035)
 static const char *YEAR_OPTIONS =
     "2024\n2025\n2026\n2027\n2028\n2029\n2030\n2031\n2032\n2033\n2034\n2035";
@@ -189,6 +214,183 @@ static void manual_set_btn_cb(lv_event_t *e)
 }
 
 /**
+ * @brief Network list item click callback
+ */
+static void network_select_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_CLICKED) return;
+
+    int idx = (int)(uintptr_t)lv_event_get_user_data(e);
+
+    if (idx >= 0 && idx < s_cached_count) {
+        strncpy(s_selected_ssid, s_cached_results[idx].ssid, sizeof(s_selected_ssid) - 1);
+        s_selected_ssid[sizeof(s_selected_ssid) - 1] = '\0';
+
+        if (s_selected_ssid_label) {
+            lv_label_set_text(s_selected_ssid_label, s_selected_ssid);
+        }
+
+        ESP_LOGI(TAG, "Selected network: %s", s_selected_ssid);
+    }
+}
+
+/**
+ * @brief Scan complete callback (called from system event task)
+ * NOTE: This runs in a different task context, so we CANNOT call LVGL functions directly.
+ * Instead, we store results and set a flag for the UI task to process.
+ */
+static void on_scan_complete(network_scan_result_t *results, uint16_t count)
+{
+    ESP_LOGI(TAG, "Scan complete, %d networks found", count);
+
+    // Cache results (thread-safe: only writes to static buffer)
+    s_cached_count = count > MAX_SCAN_RESULTS ? MAX_SCAN_RESULTS : count;
+    if (s_cached_count > 0) {
+        memcpy(s_cached_results, results, sizeof(network_scan_result_t) * s_cached_count);
+    }
+
+    // Set flag for UI task to process (must be last)
+    s_scan_complete_pending = true;
+}
+
+/**
+ * @brief Process scan results in LVGL context (called from ui_network_update)
+ */
+static void process_scan_results(void)
+{
+    if (!s_scan_complete_pending) return;
+    s_scan_complete_pending = false;
+
+    ESP_LOGI(TAG, "Processing scan results in UI context");
+
+    // Reset scan button
+    if (s_scan_btn_label) {
+        lv_label_set_text(s_scan_btn_label, "Scan");
+    }
+
+    // Clear and repopulate list
+    if (s_network_list) {
+        lv_obj_clean(s_network_list);
+
+        for (int i = 0; i < s_cached_count; i++) {
+            char label[48];
+            const char *lock = (s_cached_results[i].authmode != WIFI_AUTH_OPEN) ? "*" : "";
+            // Truncate SSID to fit: "*" + SSID(max 32) + " (-XXX dBm)" = ~45 chars
+            snprintf(label, sizeof(label), "%s%.28s (%d)",
+                     lock, s_cached_results[i].ssid, s_cached_results[i].rssi);
+
+            lv_obj_t *btn = lv_list_add_button(s_network_list, LV_SYMBOL_WIFI, label);
+            lv_obj_add_event_cb(btn, network_select_cb, LV_EVENT_CLICKED, (void *)(uintptr_t)i);
+        }
+
+        if (s_cached_count == 0) {
+            lv_obj_t *label = lv_label_create(s_network_list);
+            lv_label_set_text(label, "No networks found");
+            lv_obj_set_style_text_color(label, lv_color_hex(0xAAAAAA), 0);
+        }
+    }
+}
+
+/**
+ * @brief Scan button callback
+ */
+static void scan_btn_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_RELEASED) return;
+
+    if (network_is_scanning()) {
+        ESP_LOGW(TAG, "Scan already in progress");
+        return;
+    }
+
+    if (s_scan_btn_label) {
+        lv_label_set_text(s_scan_btn_label, "Scanning...");
+    }
+
+    esp_err_t ret = network_scan_start(on_scan_complete);
+    if (ret != ESP_OK) {
+        if (s_scan_btn_label) {
+            lv_label_set_text(s_scan_btn_label, "Scan Failed");
+        }
+        ESP_LOGE(TAG, "Failed to start scan: %s", esp_err_to_name(ret));
+    }
+}
+
+/**
+ * @brief Password textarea focus callback - show/hide keyboard
+ */
+static void password_textarea_cb(lv_event_t *e)
+{
+    lv_event_code_t code = lv_event_get_code(e);
+
+    ESP_LOGI(TAG, "Password textarea event: %d", code);
+
+    if (code == LV_EVENT_FOCUSED || code == LV_EVENT_CLICKED) {
+        if (s_keyboard) {
+            ESP_LOGI(TAG, "Showing keyboard");
+            lv_keyboard_set_textarea(s_keyboard, s_password_textarea);
+            lv_obj_remove_flag(s_keyboard, LV_OBJ_FLAG_HIDDEN);
+            lv_obj_move_foreground(s_keyboard);
+        }
+    } else if (code == LV_EVENT_DEFOCUSED || code == LV_EVENT_READY) {
+        if (s_keyboard) {
+            ESP_LOGI(TAG, "Hiding keyboard");
+            lv_obj_add_flag(s_keyboard, LV_OBJ_FLAG_HIDDEN);
+            lv_keyboard_set_textarea(s_keyboard, NULL);
+        }
+    }
+}
+
+/**
+ * @brief Connect button callback
+ */
+static void connect_btn_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_RELEASED) return;
+
+    if (strlen(s_selected_ssid) == 0) {
+        ESP_LOGW(TAG, "No network selected");
+        return;
+    }
+
+    const char *password = NULL;
+    if (s_password_textarea) {
+        password = lv_textarea_get_text(s_password_textarea);
+    }
+
+    ESP_LOGI(TAG, "Connecting to: %s", s_selected_ssid);
+
+    esp_err_t ret = network_connect(s_selected_ssid, password);
+    if (ret == ESP_OK) {
+        // Save credentials
+        network_save_credentials(s_selected_ssid, password);
+    } else {
+        ESP_LOGE(TAG, "Failed to connect: %s", esp_err_to_name(ret));
+    }
+}
+
+/**
+ * @brief Coprocessor retry button callback
+ */
+static void retry_coprocessor_cb(lv_event_t *e)
+{
+    if (lv_event_get_code(e) != LV_EVENT_RELEASED) return;
+
+    ESP_LOGI(TAG, "Retrying coprocessor connection...");
+    esp_err_t ret = network_reset_coprocessor();
+
+    if (ret == ESP_OK) {
+        // Hide error panel and reinitialize normal UI
+        if (s_error_panel) {
+            lv_obj_add_flag(s_error_panel, LV_OBJ_FLAG_HIDDEN);
+        }
+        update_wifi_status();
+    } else {
+        ESP_LOGE(TAG, "Coprocessor retry failed");
+    }
+}
+
+/**
  * @brief WOL send button callback
  */
 static void wol_btn_cb(lv_event_t *e)
@@ -246,6 +448,50 @@ void ui_network_init(lv_obj_t *parent)
 
     ESP_LOGI(TAG, "Initializing network UI");
 
+    // Check coprocessor availability first
+    if (!network_is_coprocessor_available()) {
+        ESP_LOGW(TAG, "Coprocessor not available, showing error UI");
+
+        // Create error panel
+        s_error_panel = lv_obj_create(parent);
+        lv_obj_set_size(s_error_panel, LV_PCT(100), LV_SIZE_CONTENT);
+        lv_obj_set_flex_flow(s_error_panel, LV_FLEX_FLOW_COLUMN);
+        lv_obj_set_flex_align(s_error_panel, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+        lv_obj_set_style_bg_color(s_error_panel, lv_color_hex(0x331111), 0);
+        lv_obj_set_style_border_color(s_error_panel, lv_color_hex(0xFF6666), 0);
+        lv_obj_set_style_pad_all(s_error_panel, 20, 0);
+        lv_obj_set_style_pad_row(s_error_panel, 15, 0);
+
+        lv_obj_t *error_icon = lv_label_create(s_error_panel);
+        lv_label_set_text(error_icon, LV_SYMBOL_WARNING);
+        lv_obj_set_style_text_font(error_icon, &lv_font_montserrat_24, 0);
+        lv_obj_set_style_text_color(error_icon, lv_color_hex(0xFF6666), 0);
+
+        lv_obj_t *error_label = lv_label_create(s_error_panel);
+        lv_label_set_text(error_label, "WiFi Unavailable");
+        lv_obj_set_style_text_font(error_label, &lv_font_montserrat_18, 0);
+        lv_obj_set_style_text_color(error_label, lv_color_hex(0xFF6666), 0);
+
+        lv_obj_t *error_desc = lv_label_create(s_error_panel);
+        lv_label_set_text(error_desc, "ESP-Hosted coprocessor\nnot responding");
+        lv_obj_set_style_text_font(error_desc, &lv_font_montserrat_14, 0);
+        lv_obj_set_style_text_color(error_desc, lv_color_hex(0xAAAAAA), 0);
+        lv_obj_set_style_text_align(error_desc, LV_TEXT_ALIGN_CENTER, 0);
+
+        s_retry_btn = lv_button_create(s_error_panel);
+        lv_obj_set_size(s_retry_btn, 160, 45);
+        lv_obj_add_event_cb(s_retry_btn, retry_coprocessor_cb, LV_EVENT_RELEASED, NULL);
+        lv_obj_set_style_bg_color(s_retry_btn, lv_color_hex(0x2196F3), 0);
+
+        lv_obj_t *retry_label = lv_label_create(s_retry_btn);
+        lv_label_set_text(retry_label, "Retry Connection");
+        lv_obj_set_style_text_font(retry_label, &lv_font_montserrat_14, 0);
+        lv_obj_center(retry_label);
+
+        ESP_LOGI(TAG, "Network UI initialized (error mode)");
+        return;
+    }
+
     // Create network settings section
     s_network_panel = lv_obj_create(parent);
     lv_obj_set_size(s_network_panel, LV_PCT(100), LV_SIZE_CONTENT);
@@ -255,6 +501,7 @@ void ui_network_init(lv_obj_t *parent)
     lv_obj_set_style_border_width(s_network_panel, 0, 0);
     lv_obj_set_style_pad_all(s_network_panel, 0, 0);
     lv_obj_set_style_pad_row(s_network_panel, 10, 0);
+    lv_obj_remove_flag(s_network_panel, LV_OBJ_FLAG_SCROLLABLE);  // Prevent scroll from blocking clicks
 
     // ========== Network & Time Title ==========
     lv_obj_t *title = lv_label_create(s_network_panel);
@@ -279,6 +526,96 @@ void ui_network_init(lv_obj_t *parent)
     s_wifi_status_label = lv_label_create(wifi_row);
     lv_label_set_text(s_wifi_status_label, "Checking...");
     lv_obj_set_style_text_font(s_wifi_status_label, &lv_font_montserrat_14, 0);
+
+    // ========== WiFi Network Scanner ==========
+    lv_obj_t *scanner_label = lv_label_create(s_network_panel);
+    lv_label_set_text(scanner_label, "WiFi Networks:");
+    lv_obj_set_style_text_font(scanner_label, &lv_font_montserrat_14, 0);
+    lv_obj_set_style_text_color(scanner_label, lv_color_hex(0xFFFFFF), 0);
+
+    // Scan button
+    s_scan_btn = lv_button_create(s_network_panel);
+    lv_obj_set_size(s_scan_btn, 120, 35);
+    lv_obj_add_event_cb(s_scan_btn, scan_btn_cb, LV_EVENT_RELEASED, NULL);
+    lv_obj_set_style_bg_color(s_scan_btn, lv_color_hex(0x4CAF50), 0);
+
+    s_scan_btn_label = lv_label_create(s_scan_btn);
+    lv_label_set_text(s_scan_btn_label, "Scan");
+    lv_obj_set_style_text_font(s_scan_btn_label, &lv_font_montserrat_14, 0);
+    lv_obj_center(s_scan_btn_label);
+
+    // Network list
+    s_network_list = lv_list_create(s_network_panel);
+    lv_obj_set_size(s_network_list, 280, 120);
+    lv_obj_set_style_bg_color(s_network_list, lv_color_hex(0x222222), 0);
+    lv_obj_set_style_border_color(s_network_list, lv_color_hex(0x444444), 0);
+
+    lv_obj_t *placeholder = lv_label_create(s_network_list);
+    lv_label_set_text(placeholder, "Press Scan to find networks");
+    lv_obj_set_style_text_color(placeholder, lv_color_hex(0x888888), 0);
+    lv_obj_set_style_text_font(placeholder, &lv_font_montserrat_12, 0);
+
+    // Selected network display
+    lv_obj_t *selected_row = lv_obj_create(s_network_panel);
+    lv_obj_set_size(selected_row, 280, 30);
+    lv_obj_set_flex_flow(selected_row, LV_FLEX_FLOW_ROW);
+    lv_obj_set_flex_align(selected_row, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_bg_opa(selected_row, LV_OPA_TRANSP, 0);
+    lv_obj_set_style_border_width(selected_row, 0, 0);
+    lv_obj_set_style_pad_all(selected_row, 0, 0);
+    lv_obj_set_style_pad_column(selected_row, 8, 0);
+
+    lv_obj_t *selected_label = lv_label_create(selected_row);
+    lv_label_set_text(selected_label, "Selected:");
+    lv_obj_set_style_text_font(selected_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_color(selected_label, lv_color_hex(0xAAAAAA), 0);
+
+    s_selected_ssid_label = lv_label_create(selected_row);
+    lv_label_set_text(s_selected_ssid_label, "(none)");
+    lv_obj_set_style_text_font(s_selected_ssid_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_color(s_selected_ssid_label, lv_color_hex(0x00AAFF), 0);
+
+    // Password input
+    lv_obj_t *pass_label = lv_label_create(s_network_panel);
+    lv_label_set_text(pass_label, "Password:");
+    lv_obj_set_style_text_font(pass_label, &lv_font_montserrat_12, 0);
+    lv_obj_set_style_text_color(pass_label, lv_color_hex(0xAAAAAA), 0);
+
+    s_password_textarea = lv_textarea_create(s_network_panel);
+    lv_obj_set_size(s_password_textarea, 250, 40);
+    lv_textarea_set_one_line(s_password_textarea, true);
+    lv_textarea_set_password_mode(s_password_textarea, true);
+    lv_textarea_set_placeholder_text(s_password_textarea, "Enter password");
+    lv_obj_set_style_text_font(s_password_textarea, &lv_font_montserrat_14, 0);
+    // Ensure textarea can receive click events
+    lv_obj_add_flag(s_password_textarea, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_add_flag(s_password_textarea, LV_OBJ_FLAG_CLICK_FOCUSABLE);
+    lv_obj_remove_flag(s_password_textarea, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_add_event_cb(s_password_textarea, password_textarea_cb, LV_EVENT_CLICKED, NULL);
+    lv_obj_add_event_cb(s_password_textarea, password_textarea_cb, LV_EVENT_FOCUSED, NULL);
+    lv_obj_add_event_cb(s_password_textarea, password_textarea_cb, LV_EVENT_DEFOCUSED, NULL);
+    lv_obj_add_event_cb(s_password_textarea, password_textarea_cb, LV_EVENT_READY, NULL);
+    ESP_LOGI(TAG, "Password textarea created: %p", (void*)s_password_textarea);
+
+    // On-screen keyboard (created on parent's screen for proper z-order)
+    lv_obj_t *screen = lv_obj_get_screen(parent);
+    s_keyboard = lv_keyboard_create(screen);
+    lv_obj_set_size(s_keyboard, LV_PCT(100), 220);
+    lv_obj_align(s_keyboard, LV_ALIGN_BOTTOM_MID, 0, 0);
+    lv_obj_add_flag(s_keyboard, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_move_foreground(s_keyboard);  // Ensure keyboard is on top
+    ESP_LOGI(TAG, "Keyboard created on screen %p", (void*)screen);
+
+    // Connect button
+    s_connect_btn = lv_button_create(s_network_panel);
+    lv_obj_set_size(s_connect_btn, 140, 40);
+    lv_obj_add_event_cb(s_connect_btn, connect_btn_cb, LV_EVENT_RELEASED, NULL);
+    lv_obj_set_style_bg_color(s_connect_btn, lv_color_hex(0x2196F3), 0);
+
+    lv_obj_t *connect_label = lv_label_create(s_connect_btn);
+    lv_label_set_text(connect_label, "Connect");
+    lv_obj_set_style_text_font(connect_label, &lv_font_montserrat_14, 0);
+    lv_obj_center(connect_label);
 
     // ========== NTP Server Selection ==========
     lv_obj_t *ntp_label = lv_label_create(s_network_panel);
@@ -454,11 +791,32 @@ void ui_network_deinit(void)
     s_wol_target_label = NULL;
     s_wol_btn = NULL;
 
+    // Scanner UI
+    s_scan_btn = NULL;
+    s_scan_btn_label = NULL;
+    s_network_list = NULL;
+    s_password_textarea = NULL;
+    s_connect_btn = NULL;
+    s_selected_ssid_label = NULL;
+
+    // Error panel
+    s_error_panel = NULL;
+    s_retry_btn = NULL;
+
+    // Keyboard
+    s_keyboard = NULL;
+
+    // Clear selected SSID
+    memset(s_selected_ssid, 0, sizeof(s_selected_ssid));
+
     ESP_LOGI(TAG, "Network UI deinitialized");
 }
 
 void ui_network_update(void)
 {
+    // Process pending scan results (thread-safe deferred update)
+    process_scan_results();
+
     update_wifi_status();
 
     // Update NTP sync status label based on current NTP state

--- a/03.firmware/04.integratedAPP/main/main.c
+++ b/03.firmware/04.integratedAPP/main/main.c
@@ -298,11 +298,14 @@ void app_main(void)
     ESP_LOGI(TAG, "Initialization complete");
     ESP_LOGI(TAG, "Free heap: %lu bytes", esp_get_free_heap_size());
 
-    // Disable most logging but keep BLE_HID for debugging
-    // This prevents USB Serial/JTAG blocking while allowing BLE debugging
+    // Disable most logging but keep important modules for debugging
+    // This prevents USB Serial/JTAG blocking while allowing debugging
     ESP_LOGI(TAG, "Reducing runtime logs for standalone operation");
     esp_log_level_set("*", ESP_LOG_WARN);
     esp_log_level_set("BLE_HID", ESP_LOG_INFO);
+    esp_log_level_set("NETWORK", ESP_LOG_INFO);
+    esp_log_level_set("UI_NETWORK", ESP_LOG_INFO);
+    esp_log_level_set("NTP", ESP_LOG_INFO);
 
     // Main loop - LVGL timer handling is done by esp_lvgl_port
     while (1) {


### PR DESCRIPTION
## Summary
- NTP同期タイムアウト処理（30秒でFAILED状態）
- WiFi指数バックオフ再接続（1s→2s→4s...最大60秒）
- WiFiネットワークスキャナーUI（スキャン・選択・キーボード・接続）
- ESP-Hostedコプロセッサ回復API

## Changes
| File | Description |
|------|-------------|
| `network.h` | スキャンAPI、コプロセッサAPI追加 |
| `network.c` | 指数バックオフ、スキャン、コプロセッサ回復実装 |
| `ntp.h/ntp.c` | タイムアウトタイマー実装 |
| `ui_network.c` | スキャナーUI、キーボード、コプロセッサエラー表示 |
| `main.c` | デバッグログレベル設定追加 |

## Bug Fixes
- スキャンコールバックのスレッドセーフティ（LVGL UI更新をdeferred処理）
- キーボード表示（正しいスクリーンに作成）
- 既存接続時のdisconnect-before-connect

## Test plan
- [x] WiFiスキャン動作確認
- [x] WiFi接続（キーボード入力含む）
- [x] NTP同期
- [x] 指数バックオフ（1s→2s→4s→8s→16s確認）
- [ ] NTPタイムアウト（30秒）※インターネット遮断が必要
- [ ] コプロセッサ回復 ※障害発生困難

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)